### PR TITLE
Tests were failing on 5.1.7-arch1-1-ARCH

### DIFF
--- a/core/src/main/java/org/quickperf/WorkingFolder.java
+++ b/core/src/main/java/org/quickperf/WorkingFolder.java
@@ -13,10 +13,12 @@
 
 package org.quickperf;
 
-import java.io.File;
-import java.util.concurrent.ThreadLocalRandom;
+import java.io.IOException;
+import java.nio.file.Files;
 
 public class WorkingFolder {
+
+    private static final WorkingFolder NONE = new WorkingFolder("");
 
     private final String path;
 
@@ -31,23 +33,21 @@ public class WorkingFolder {
             return new WorkingFolder(path);
         }
 
-        String path = buildWorkingFolderPath();
         if (hasTestMethodToBeLaunchedInASpecificJvm) {
-            createFileFrom(path);
+            String path = createTempDirectory();
+            return new WorkingFolder(path);
         }
-        return new WorkingFolder(path);
+
+        return NONE;
 
     }
 
-    private static String buildWorkingFolderPath() {
-        String tmpDirPath = System.getProperty("java.io.tmpdir");
-        int randomInt = Math.abs(ThreadLocalRandom.current().nextInt());
-        return tmpDirPath + "QuickPerf-" + randomInt;
-    }
-
-    private static void createFileFrom(String filePath) {
-        File file = new File(filePath);
-        file.mkdir();
+    private static String createTempDirectory() {
+        try {
+            return Files.createTempDirectory("QuickPerf-").toString();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     public String getPath() {


### PR DESCRIPTION
## Bug
Tests were failing with the following stack 
```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running org.quickperf.junit4.QuickPerfJUnitRunnerTest

Unable to run test in a new JMV: Exception in thread "main" java.lang.IllegalStateException: java.io.FileNotFoundException: /tmpQuickPerf-1470442387/junitFailures.ser (Aucun fichier ou dossier de ce type)
	at org.quickperf.repository.ObjectOutputStreamBuilder.buildFileOutputStream(ObjectOutputStreamBuilder.java:51)
	at org.quickperf.repository.ObjectOutputStreamBuilder.build(ObjectOutputStreamBuilder.java:33)
	at org.quickperf.repository.ObjectFileRepository.save(ObjectFileRepository.java:40)
	at org.quickperf.junit4.JUnit4FailuresRepository.save(JUnit4FailuresRepository.java:37)
	at org.quickperf.junit4.QuickPerfJunit4Core.main(QuickPerfJunit4Core.java:37)
Caused by: java.io.FileNotFoundException: /tmpQuickPerf-1470442387/junitFailures.ser (Aucun fichier ou dossier de ce type)
	at java.base/java.io.FileOutputStream.open0(Native Method)
	at java.base/java.io.FileOutputStream.open(FileOutputStream.java:298)
	at java.base/java.io.FileOutputStream.<init>(FileOutputStream.java:237)
	at java.base/java.io.FileOutputStream.<init>(FileOutputStream.java:187)
	at org.quickperf.repository.ObjectOutputStreamBuilder.buildFileOutputStream(ObjectOutputStreamBuilder.java:49)
	... 4 more

Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.181 s <<< FAILURE! - in org.quickperf.junit4.QuickPerfJUnitRunnerTest
a_test_with_failing_business_code_and_a_performance_issue_in_a_specific_jvm(org.quickperf.junit4.QuickPerfJUnitRunnerTest)  Time elapsed: 1.181 s  <<< FAILURE!
org.assertj.core.api.SoftAssertionError: 

The following assertion failed:
1) 
Expecting:
 <"
Time: 1,146
There was 1 failure:
1) failing_test(org.quickperf.junit4.ClassWithFuntionalIssueInNewJvmAndPerfIssue)
java.lang.IllegalStateException: java.io.FileNotFoundException: /tmpQuickPerf-1470442387/allocation.ser (Aucun fichier ou dossier de ce type)
	at org.quickperf.repository.ObjectInputStreamBuilder.buildFileInputStream(ObjectInputStreamBuilder.java:48)
	at org.quickperf.repository.ObjectInputStreamBuilder.buildObjectInputStream(ObjectInputStreamBuilder.java:30)
	at org.quickperf.repository.LongFileRepository.retrieveLongValueFromFile(LongFileRepository.java:58)
	at org.quickperf.repository.LongFileRepository.find(LongFileRepository.java:49)
	at org.quickperf.jvm.allocation.AllocationRepository.findAllocation(AllocationRepository.java:34)
	at org.quickperf.jvm.allocation.bytewatcher.ByteWatcherRecorder.findRecord(ByteWatcherRecorder.java:64)
	at org.quickperf.jvm.allocation.bytewatcher.ByteWatcherRecorder.findRecord(ByteWatcherRecorder.java:21)
	at org.quickperf.junit4.MainJvmAfterJUnitStatement.findPerfRecord(MainJvmAfterJUnitStatement.java:210)
	at org.quickperf.junit4.MainJvmAfterJUnitStatement.buildPerfRecordByAnnotation(MainJvmAfterJUnitStatement.java:200)
	at org.quickperf.junit4.MainJvmAfterJUnitStatement.evaluate(MainJvmAfterJUnitStatement.java:84)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
	at org.junit.experimental.results.PrintableResult.testResult(PrintableResult.java:36)
	at org.junit.experimental.results.PrintableResult.testResult(PrintableResult.java:29)
	at org.quickperf.junit4.QuickPerfJUnitRunnerTest.a_test_with_failing_business_code_and_a_performance_issue_in_a_specific_jvm(QuickPerfJUnitRunnerTest.java:50)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.apache.maven.surefire.junitcore.pc.Scheduler$1.run(Scheduler.java:410)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.io.FileNotFoundException: /tmpQuickPerf-1470442387/allocation.ser (Aucun fichier ou dossier de ce type)
	at java.base/java.io.FileInputStream.open0(Native Method)
	at java.base/java.io.FileInputStream.open(FileInputStream.java:219)
	at java.base/java.io.FileInputStream.<init>(FileInputStream.java:157)
	at org.quickperf.repository.ObjectInputStreamBuilder.buildFileInputStream(ObjectInputStreamBuilder.java:46)
	... 41 more

FAILURES!!!
Tests run: 1,  Failures: 1

">
to contain:
 <"Performance and functional properties not respected"> 

	at org.quickperf.junit4.QuickPerfJUnitRunnerTest.a_test_with_failing_business_code_and_a_performance_issue_in_a_specific_jvm(QuickPerfJUnitRunnerTest.java:57)


Results:

Failures: 
  QuickPerfJUnitRunnerTest.a_test_with_failing_business_code_and_a_performance_issue_in_a_specific_jvm:57 
The following assertion failed:
1) 
Expecting:
 <"
Time: 1,146
There was 1 failure:
1) failing_test(org.quickperf.junit4.ClassWithFuntionalIssueInNewJvmAndPerfIssue)
java.lang.IllegalStateException: java.io.FileNotFoundException: /tmpQuickPerf-1470442387/allocation.ser (Aucun fichier ou dossier de ce type)
	at org.quickperf.repository.ObjectInputStreamBuilder.buildFileInputStream(ObjectInputStreamBuilder.java:48)
	at org.quickperf.repository.ObjectInputStreamBuilder.buildObjectInputStream(ObjectInputStreamBuilder.java:30)
	at org.quickperf.repository.LongFileRepository.retrieveLongValueFromFile(LongFileRepository.java:58)
	at org.quickperf.repository.LongFileRepository.find(LongFileRepository.java:49)
	at org.quickperf.jvm.allocation.AllocationRepository.findAllocation(AllocationRepository.java:34)
	at org.quickperf.jvm.allocation.bytewatcher.ByteWatcherRecorder.findRecord(ByteWatcherRecorder.java:64)
	at org.quickperf.jvm.allocation.bytewatcher.ByteWatcherRecorder.findRecord(ByteWatcherRecorder.java:21)
	at org.quickperf.junit4.MainJvmAfterJUnitStatement.findPerfRecord(MainJvmAfterJUnitStatement.java:210)
	at org.quickperf.junit4.MainJvmAfterJUnitStatement.buildPerfRecordByAnnotation(MainJvmAfterJUnitStatement.java:200)
	at org.quickperf.junit4.MainJvmAfterJUnitStatement.evaluate(MainJvmAfterJUnitStatement.java:84)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
	at org.junit.experimental.results.PrintableResult.testResult(PrintableResult.java:36)
	at org.junit.experimental.results.PrintableResult.testResult(PrintableResult.java:29)
	at org.quickperf.junit4.QuickPerfJUnitRunnerTest.a_test_with_failing_business_code_and_a_performance_issue_in_a_specific_jvm(QuickPerfJUnitRunnerTest.java:50)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.apache.maven.surefire.junitcore.pc.Scheduler$1.run(Scheduler.java:410)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.io.FileNotFoundException: /tmpQuickPerf-1470442387/allocation.ser (Aucun fichier ou dossier de ce type)
	at java.base/java.io.FileInputStream.open0(Native Method)
	at java.base/java.io.FileInputStream.open(FileInputStream.java:219)
	at java.base/java.io.FileInputStream.<init>(FileInputStream.java:157)
	at org.quickperf.repository.ObjectInputStreamBuilder.buildFileInputStream(ObjectInputStreamBuilder.java:46)
	... 41 more

FAILURES!!!
Tests run: 1,  Failures: 1

">
to contain:
 <"Performance and functional properties not respected"> 


Tests run: 2, Failures: 1, Errors: 0, Skipped: 0
```

## Fix
Use java nio temp directory creation