### PR TITLE
Add annotation @ExpectMaxUpdatedColumn

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,17 @@ Many thanks to all our contributors!
             </a>
             <br/>
             <a href="https://github.com/quick-perf/quickperf/commits?author=rdm100" title="Documentation">📖</a>
-        </td>       
+        </td>
+        <td align="center">
+            <a href="https://github.com/Artus2b">
+                <img src="https://avatars1.githubusercontent.com/u/3645691?v=4" width="100px;"  alt="Artus de Benque"/>
+                <br/>
+                <sub><b>Artus de Benque</b></sub>
+            </a>
+            <br/>
+            <a href="https://github.com/quick-perf/quickperf/commits?author=ablanchard" title="Bug reports">🐛</a>
+            <a href="https://github.com/quick-perf/quickperf/commits?author=ablanchard" title="Code">💻</a>
+        </td>                  
     </tr>
 </table>
 <a href = "https://allcontributors.org/docs/en/emoji-key">emoji key</a>

--- a/pom.xml
+++ b/pom.xml
@@ -304,6 +304,10 @@
             <url>https://github.com/ablanchard</url>
         </contributor>
         <contributor>
+            <name>Artus de Benque</name>
+            <url>https://github.com/Artus2b</url>
+        </contributor>
+        <contributor>
             <name>Patrice Cavezzan</name>
             <url>https://github.com/pcavezzan</url>
         </contributor>

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/annotation/ExpectMaxUpdatedColumn.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/annotation/ExpectMaxUpdatedColumn.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2019 the original author or authors.
+ */
+
+package org.quickperf.sql.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface ExpectMaxUpdatedColumn {
+
+    int value() default 0;
+
+}

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/config/library/SqlAnnotationsConfigs.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/config/library/SqlAnnotationsConfigs.java
@@ -35,6 +35,8 @@ import org.quickperf.sql.select.columns.SelectedColumnNumberPerfIssueVerifier;
 import org.quickperf.sql.select.columns.SelectedColumnNumberPerfMeasureExtractor;
 import org.quickperf.sql.update.UpdateCountMeasureExtractor;
 import org.quickperf.sql.update.UpdateNumberPerfIssueVerifier;
+import org.quickperf.sql.update.columns.MaxUpdatedColumnsPerMeasureExtractor;
+import org.quickperf.sql.update.columns.MaxUpdatedColumnsPerfIssueVerifier;
 
 class SqlAnnotationsConfigs {
 
@@ -108,6 +110,12 @@ class SqlAnnotationsConfigs {
             .perfMeasureExtractor(MaxSelectedColumnsPerMeasureExtractor.INSTANCE)
             .perfIssueVerifier(MaxSelectedColumnsPerfIssueVerifier.INSTANCE)
             .build(ExpectMaxSelectedColumn.class);
+
+	static final AnnotationConfig MAX_UPDATED_COLUMNS = new AnnotationConfig.Builder()
+			.perfRecorderClass(PersistenceSqlRecorder.class)
+			.perfMeasureExtractor(MaxUpdatedColumnsPerMeasureExtractor.INSTANCE)
+			.perfIssueVerifier(MaxUpdatedColumnsPerfIssueVerifier.INSTANCE)
+			.build(ExpectMaxUpdatedColumn.class);
 
     static final AnnotationConfig NUMBER_OF_SELECTED_COLUMNS = new AnnotationConfig.Builder()
             .perfRecorderClass(PersistenceSqlRecorder.class)

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/config/library/SqlConfigLoader.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/config/library/SqlConfigLoader.java
@@ -35,6 +35,7 @@ public class SqlConfigLoader implements QuickPerfConfigLoader {
                 , SqlAnnotationsConfigs.NUMBER_OF_SQL_DELETE
                 , SqlAnnotationsConfigs.NUMBER_OF_SQL_UPDATE
                 , SqlAnnotationsConfigs.MAX_SELECTED_COLUMNS
+                , SqlAnnotationsConfigs.MAX_UPDATED_COLUMNS
                 , SqlAnnotationsConfigs.NUMBER_OF_SELECTED_COLUMNS
                 , SqlAnnotationsConfigs.DISABLE_SQL_CROSS_JOIN
                 , SqlAnnotationsConfigs.ENABLE_SQL_CROSS_JOIN

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/select/columns/MaxSelectedColumnsPerMeasureExtractor.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/select/columns/MaxSelectedColumnsPerMeasureExtractor.java
@@ -25,7 +25,7 @@ public class MaxSelectedColumnsPerMeasureExtractor implements ExtractablePerform
 
     @Override
     public Count extractPerfMeasureFrom(SqlExecutions sqlExecutions) {
-        long maxNumberOfColumns = sqlExecutions.getMaxNumberOfColumns();
+        long maxNumberOfColumns = sqlExecutions.getMaxNumberOfSelectedColumns();
         return new Count(maxNumberOfColumns);
     }
 

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/update/columns/MaxUpdatedColumnsPerMeasureExtractor.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/update/columns/MaxUpdatedColumnsPerMeasureExtractor.java
@@ -11,22 +11,22 @@
  * Copyright 2019-2019 the original author or authors.
  */
 
-package org.quickperf.sql.select.columns;
+package org.quickperf.sql.update.columns;
 
 import org.quickperf.ExtractablePerformanceMeasure;
 import org.quickperf.sql.SqlExecutions;
 import org.quickperf.unit.Count;
 
-public class SelectedColumnNumberPerfMeasureExtractor implements ExtractablePerformanceMeasure<SqlExecutions, Count>  {
+public class MaxUpdatedColumnsPerMeasureExtractor implements ExtractablePerformanceMeasure<SqlExecutions, Count> {
 
-    public static final SelectedColumnNumberPerfMeasureExtractor INSTANCE = new SelectedColumnNumberPerfMeasureExtractor();
+    public static final MaxUpdatedColumnsPerMeasureExtractor INSTANCE = new MaxUpdatedColumnsPerMeasureExtractor();
 
-    private SelectedColumnNumberPerfMeasureExtractor() {}
+    private MaxUpdatedColumnsPerMeasureExtractor() {}
 
     @Override
-    public Count extractPerfMeasureFrom(SqlExecutions sqlExecutions) {
-        long maxNumberOfColumns = sqlExecutions.getMaxNumberOfSelectedColumns();
-        return new Count(maxNumberOfColumns);
+    public Count extractPerfMeasureFrom(SqlExecutions perfRecord) {
+        long numberOfUpdatedColumns = perfRecord.getMaxNumberOfUpdatedColumn();
+        return new Count(numberOfUpdatedColumns);
     }
 
 }

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/update/columns/MaxUpdatedColumnsPerfIssueVerifier.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/update/columns/MaxUpdatedColumnsPerfIssueVerifier.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2019 the original author or authors.
+ */
+
+package org.quickperf.sql.update.columns;
+
+import org.quickperf.issue.PerfIssue;
+import org.quickperf.issue.VerifiablePerformanceIssue;
+import org.quickperf.sql.annotation.ExpectMaxUpdatedColumn;
+import org.quickperf.unit.Count;
+
+public class MaxUpdatedColumnsPerfIssueVerifier implements VerifiablePerformanceIssue<ExpectMaxUpdatedColumn, Count> {
+
+    public static final MaxUpdatedColumnsPerfIssueVerifier INSTANCE = new MaxUpdatedColumnsPerfIssueVerifier();
+
+    private MaxUpdatedColumnsPerfIssueVerifier() {}
+
+    @Override
+    public PerfIssue verifyPerfIssue(ExpectMaxUpdatedColumn annotation, Count maxSqlCountMeasure) {
+
+        Count expectedCount = new Count(annotation.value());
+
+        if(maxSqlCountMeasure.isGreaterThan(expectedCount)) {
+            return buildPerfIssue(maxSqlCountMeasure, expectedCount);
+        }
+
+        return PerfIssue.NONE;
+
+    }
+
+    private PerfIssue buildPerfIssue(Count maxSqlCountMeasure, Count expectedCount) {
+        String description =
+                    "Maximum expected number of updated columns "
+                  + "<" + expectedCount.getValue() + ">"
+                  + " but is "
+                  + "<" + maxSqlCountMeasure.getValue() + ">" + "."
+                  + System.lineSeparator()
+                  + System.lineSeparator()
+                  + "The following requests were executed: "
+                  + System.lineSeparator()
+                  + maxSqlCountMeasure.getComment();
+        return new PerfIssue(description);
+    }
+
+}

--- a/sql/sql-integration-test/src/test/java/ExpectMaxUpdatedColumnTest.java
+++ b/sql/sql-integration-test/src/test/java/ExpectMaxUpdatedColumnTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2019 the original author or authors.
+ */
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.Test;
+import org.junit.experimental.results.PrintableResult;
+import org.junit.runner.RunWith;
+import org.quickperf.junit4.QuickPerfJUnitRunner;
+import org.quickperf.sql.annotation.ExpectMaxUpdatedColumn;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExpectMaxUpdatedColumnTest {
+
+    @RunWith(QuickPerfJUnitRunner.class)
+    @ExpectMaxUpdatedColumn(2)
+    public static class AClassAnnotatedWithExpectMaxUpdatedColumnPassing extends SqlTestBase {
+
+        @Test
+        public void execute_update_with_two_columns_updated_and_a_where_clause() {
+            EntityManager em = emf.createEntityManager();
+            em.getTransaction().begin();
+            Query nativeQuery = em.createNativeQuery("UPDATE book SET isbn = :isbn, title = :title WHERE id = :id")
+                               .setParameter("isbn", 12)
+                               .setParameter("title", "Manon")
+                               .setParameter("id", 40);
+            nativeQuery.executeUpdate();
+            em.getTransaction().commit();
+        }
+
+    }
+
+    @Test public void
+    should_pass_if_the_number_of_sql_updates_is_equal_to_the_number_expected_with_annotation_on_method() {
+
+        // GIVEN
+        Class<?> testClass = AClassAnnotatedWithExpectMaxUpdatedColumnPassing.class;
+
+        // WHEN
+        PrintableResult printableResult = PrintableResult.testResult(testClass);
+
+        // THEN
+        assertThat(printableResult.failureCount()).isEqualTo(0);
+
+    }
+
+    @RunWith(QuickPerfJUnitRunner.class)
+    @ExpectMaxUpdatedColumn(1)
+    public static class AClassAnnotatedWithExpectMaxUpdatedColumnFailing extends SqlTestBase {
+
+        @Test
+        public void execute_update_with_two_columns_updated() {
+            EntityManager em = emf.createEntityManager();
+            em.getTransaction().begin();
+            Query nativeQuery = em.createNativeQuery("UPDATE book SET isbn = :isbn, title = :title")
+                               .setParameter("isbn", 12)
+                               .setParameter("title", "Manon");
+            nativeQuery.executeUpdate();
+            em.getTransaction().commit();
+        }
+
+    }
+
+    @Test public void
+    should_fail_if_the_number_of_sql_updates_is_greater_than_the_number_expected_with_annotation_on_method() {
+
+        // GIVEN
+        Class<?> testClass = AClassAnnotatedWithExpectMaxUpdatedColumnFailing.class;
+
+        // WHEN
+        PrintableResult printableResult = PrintableResult.testResult(testClass);
+
+        // THEN
+        assertThat(printableResult.failureCount()).isEqualTo(1);
+
+        SoftAssertions softAssertions = new SoftAssertions();
+        softAssertions.assertThat(printableResult.failureCount()).isEqualTo(1);
+        softAssertions.assertThat(printableResult.toString()).contains("Maximum expected number of updated columns <1> but is <2>.");
+        softAssertions.assertThat(printableResult.toString().toLowerCase())
+                      .contains("update")
+                      .contains("book")
+                      .contains("set")
+                      .contains("isbn = ?")
+                      .contains("title = ?");
+        softAssertions.assertAll();
+
+    }
+
+}


### PR DESCRIPTION
## Motivation
Users might want to ensure that a method to not update more columns that required. By putting `@ExpectMaxUpdatedColumn(3)` quickperf wil assert that no more than 3 columns have been updated.

## Implementation
### Context
We want to count columns passed in the update SQL query. We will count the parameter setted in the set clause of the query. We suppose also that with are using `PreparedStatement` to execute this update. This is what hibernate do.
### Counting
How to return `2` in this example `UPDATE book SET isbn = ?, title = ? WHERE id = ?`
To count updated columns, we cannot rely on `query.getParametersList().get(0)` because this list will contains all 3 parameters of the query.
Instead we can count the occurrences of the character `?` which represent a parameter. We must count those occurrences only on the substring `SET isbn = ?, title = ?` to exclude `?` placeholders used elsewhere in the query.
### Testing
It would be great to unit test the method `SqlExecutions#countUpdatedColumn` with different string query. But the module `sql-annotations` do not have yet a testing package neither a testing framework.
So @jeanbisutti what do you think about adding one ?
### Not implemented
According to postgres documentation of Update statement (https://www.postgresql.org/docs/9.1/sql-update.html) : 
```
[ WITH [ RECURSIVE ] with_query [, ...] ]
UPDATE [ ONLY ] table [ * ] [ [ AS ] alias ]
    SET { column = { expression | DEFAULT } |
          ( column [, ...] ) = ( { expression | DEFAULT } [, ...] ) } [, ...]
    [ FROM from_list ]
    [ WHERE condition | WHERE CURRENT OF cursor_name ]
    [ RETURNING * | output_expression [ [ AS ] output_name ] [, ...] ]
```
Update can also contains `FROM` or `RETURNING`. We should consider those keywords also to extract the substring on which we do the count.
