### PR TITLE
Feature/travisci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: java
+
+os:
+  - linux
+  - osx
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      jdk: oraclejdk8
+  exclude:
+    - os: osx
+      jdk: openjdk12
+
+jdk:
+  - openjdk11
+  - openjdk12
+
+cache:
+  directories:
+    - $HOME/.m2

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <br><br>
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.quickperf/quick-perf/badge.svg)](https://search.maven.org/search?q=org.quickperf)
 [![License](https://img.shields.io/badge/license-Apache2-blue.svg)](https://github.com/quick-perf/quickperf/blob/master/LICENSE.txt)
-[![Build Status](https://travis-ci.com/pcavezzan/quickperf.svg?branch=feature%2Ftravisci)](https://travis-ci.com/pcavezzan/quickperf)
+[![Build Status](https://travis-ci.com/quick-perf/quickperf.svg?branch=master)](https://travis-ci.com/quick-perf/quickperf)
 [![Twitter Follow](https://img.shields.io/twitter/follow/QuickPerf.svg?label=Follow%20%40QuickPerf&style=social)](https://twitter.com/quickperf)
 <br><br>
 [Documentation](https://github.com/quick-perf/doc/wiki/QuickPerf)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 <br><br>
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.quickperf/quick-perf/badge.svg)](https://search.maven.org/search?q=org.quickperf)
 [![License](https://img.shields.io/badge/license-Apache2-blue.svg)](https://github.com/quick-perf/quickperf/blob/master/LICENSE.txt)
+[![Build Status](https://travis-ci.com/pcavezzan/quickperf.svg?branch=feature%2Ftravisci)](https://travis-ci.com/pcavezzan/quickperf)
 [![Twitter Follow](https://img.shields.io/twitter/follow/QuickPerf.svg?label=Follow%20%40QuickPerf&style=social)](https://twitter.com/quickperf)
 <br><br>
 [Documentation](https://github.com/quick-perf/doc/wiki/QuickPerf)


### PR DESCRIPTION
Hi @jeanbisutti ,

I finally manage to unable a building matrix into travisci to build QuickPerf and get a "quick" automate feedback, avoiding to test it manually. 

Notice, right now,  build takes usually 3min but can last 7/8 min depending the target platform.

To give you an idea about how the build looks like, you can have an overview at:
https://travis-ci.com/pcavezzan/quickperf