### PR TITLE
Added tips to build QuickPerf.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,27 @@ To build:
 * mvn clean install <br>
   To disable Spring Boot tests: mvn clean install -P -SpringBootTests
 
+## Tips
+
+To quickly test multiple linux openjdk locally, you can run thanks to docker the following commandline:
+
+```bash
+$> docker container run --rm --name mvn-quickperf-cleaninstall -v $HOME/.m2:/root/.m2 -v $(pwd):/usr/src/quickperf -w /usr/src/quickperf maven:3-jdk-11 mvn clean install
+$> docker container run --rm --name mvn-quickperf-cleaninstall -v $HOME/.m2:/root/.m2 -v $(pwd):/usr/src/quickperf -w /usr/src/quickperf maven:3-jdk-12 mvn clean install
+```
+
+See to dockerhub [the versions available for maven image](https://hub.docker.com/_/maven).
+
+And the following commandline enable us to test a list of openjdk on unix systems :
+
+```bash
+$> for i in {11..12};  do echo "******** Testing with maven:3-jdk-$i **********"; docker container run --rm --name mvn-quickperf-cleaninstall -v $HOME/.m2:/root/.m2 -v $(pwd):/usr/src/quickperf -w /usr/src/quickperf maven:3-jdk-$i mvn clean install; if [[ $? != 0 ]]; then break; fi; done
+```
+
+It will fail as soon as one mvn clean install fails.
+
+_notice: maven image are packaged only with openjdk not oraclejdk (required for jdk 1.8)._
+
 ## Legal stuff
 Project License: [Apache License Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - You will only Submit Contributions where You have authored 100% of the content.


### PR DESCRIPTION
I just added a small tips to build quickperf locally against multiple openjdk (thanks to docker).

It allow anyone who has docker installed to check linux build with multiple openjdk but it could be more like testing against amazon corretto 11 for instance.