### PR TITLE
Provides RSS annotations

### DIFF
--- a/junit4/junit4-jvm-test/src/test/java/org/quickperf/jvm/rss/JUnit4RssTests.java
+++ b/junit4/junit4-jvm-test/src/test/java/org/quickperf/jvm/rss/JUnit4RssTests.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2020 the original author or authors.
+ */
+
+package org.quickperf.jvm.rss;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.results.PrintableResult;
+import org.junit.runner.RunWith;
+import org.quickperf.junit4.QuickPerfJUnitRunner;
+import org.quickperf.jvm.allocation.AllocationUnit;
+import org.quickperf.jvm.annotations.ExpectMaxRSS;
+import org.quickperf.jvm.annotations.MeasureRSS;
+
+import java.util.Locale;
+
+import static org.junit.Assume.assumeFalse;
+import static org.junit.experimental.results.PrintableResult.testResult;
+
+public class JUnit4RssTests {
+
+    @Before
+    public void before() {
+        notWindows();
+        notMacOS();
+    }
+
+    private void notWindows() {
+        String osName = extractOSNameInLowerCase();
+        boolean onWindows = osName.contains("win");
+        assumeFalse(onWindows);
+    }
+
+    private void notMacOS() {
+        String osName = extractOSNameInLowerCase();
+        boolean onMac = osName.contains("mac");
+        assumeFalse(onMac);
+    }
+
+    private String extractOSNameInLowerCase() {
+        String osName = System.getProperty("os.name");
+        osName = osName.toLowerCase(Locale.ENGLISH);
+        return osName;
+    }
+
+    @RunWith(QuickPerfJUnitRunner.class)
+    public static class ClassWithRssAnnotations {
+
+        @MeasureRSS
+        @ExpectMaxRSS(value=10, unit = AllocationUnit.MEGA_BYTE)
+        @Test
+        public void measure_and_expect_rss() {
+        }
+    }
+
+    @Test
+    public void
+    rss_measure_expecting_10m() {
+
+        // GIVEN
+        Class<?> testClass = ClassWithRssAnnotations.class;
+
+        // WHEN
+        PrintableResult printableResult = testResult(testClass);
+
+        // THEN
+        SoftAssertions softAssertions = new SoftAssertions();
+        softAssertions.assertThat(printableResult.failureCount())
+                .isEqualTo(0);
+        softAssertions.assertAll();
+
+    }
+}

--- a/junit5/junit5-jvm-test/src/test/java/org/quickperf/junit5/jvm/rss/JUnit5RssTests.java
+++ b/junit5/junit5-jvm-test/src/test/java/org/quickperf/junit5/jvm/rss/JUnit5RssTests.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2020 the original author or authors.
+ */
+
+package org.quickperf.junit5.jvm.rss;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.quickperf.junit5.JUnit5Tests;
+import org.quickperf.junit5.JUnit5Tests.JUnit5TestsResult;
+import org.quickperf.junit5.QuickPerfTest;
+import org.quickperf.jvm.allocation.AllocationUnit;
+import org.quickperf.jvm.annotations.ExpectMaxRSS;
+import org.quickperf.jvm.annotations.MeasureRSS;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisabledOnOs({OS.WINDOWS, OS.MAC})
+public class JUnit5RssTests {
+
+    @QuickPerfTest
+    public static class ClassWithRssAnnotations {
+
+        @MeasureRSS
+        @ExpectMaxRSS(value=10, unit = AllocationUnit.MEGA_BYTE)
+        @Test
+        public void measure_and_expect_rss() {
+        }
+
+    }
+
+    @Test public void
+    rss_measure_expecting_10m() {
+
+        // GIVEN
+        Class<?> testClass = ClassWithRssAnnotations.class;
+        JUnit5Tests jUnit5Tests = JUnit5Tests.createInstance(testClass);
+
+        // WHEN
+        JUnit5TestsResult jUnit5TestsResult = jUnit5Tests.run();
+
+        // THEN
+        assertThat(jUnit5TestsResult.getNumberOfFailures()).isEqualTo(0);
+
+    }
+
+}

--- a/jvm/jvm-annotations/src/main/java/org/quickperf/jvm/annotations/ExpectMaxRSS.java
+++ b/jvm/jvm-annotations/src/main/java/org/quickperf/jvm/annotations/ExpectMaxRSS.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2020 the original author or authors.
+ */
+
+package org.quickperf.jvm.annotations;
+
+import org.quickperf.jvm.allocation.AllocationUnit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface ExpectMaxRSS {
+
+    double value();
+
+    AllocationUnit unit();
+}

--- a/jvm/jvm-annotations/src/main/java/org/quickperf/jvm/annotations/JvmAnnotationBuilder.java
+++ b/jvm/jvm-annotations/src/main/java/org/quickperf/jvm/annotations/JvmAnnotationBuilder.java
@@ -103,6 +103,32 @@ public class JvmAnnotationBuilder {
         };
     }
 
+    public static MeasureRSS measureRSS(){
+        return  new MeasureRSS() {
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return MeasureRSS.class;
+            }
+        };
+    }
+
+    public static ExpectMaxRSS expectMaxRSS(final int value, final AllocationUnit unit) {
+        return new ExpectMaxRSS() {
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return ExpectMaxRSS.class;
+            }
+            @Override
+            public double value() {
+                return value;
+            }
+            @Override
+            public AllocationUnit unit() {
+                return unit;
+            }
+        };
+    }
+
     public static ExpectNoHeapAllocation expectNoHeapAllocation() {
         return new ExpectNoHeapAllocation() {
             @Override

--- a/jvm/jvm-annotations/src/main/java/org/quickperf/jvm/annotations/MeasureRSS.java
+++ b/jvm/jvm-annotations/src/main/java/org/quickperf/jvm/annotations/MeasureRSS.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2020 the original author or authors.
+ */
+
+package org.quickperf.jvm.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface MeasureRSS {
+}

--- a/jvm/jvm-annotations/src/main/java/org/quickperf/jvm/config/library/JvmAnnotationsConfigs.java
+++ b/jvm/jvm-annotations/src/main/java/org/quickperf/jvm/config/library/JvmAnnotationsConfigs.java
@@ -22,6 +22,9 @@ import org.quickperf.jvm.annotations.*;
 import org.quickperf.jvm.jfr.JfrEventsRecorder;
 import org.quickperf.jvm.jmcrule.JmcRuleCountMeasureExtractor;
 import org.quickperf.jvm.jmcrule.JmcRulesPerfVerifier;
+import org.quickperf.jvm.rss.ExpectRssPerfVerifier;
+import org.quickperf.jvm.rss.MeasureRssPerfVerifier;
+import org.quickperf.jvm.rss.ProcessStatusRecorder;
 import org.quickperf.testlauncher.AnnotationToJvmOptionConverter;
 import org.quickperf.testlauncher.JvmOption;
 
@@ -94,5 +97,17 @@ class JvmAnnotationsConfigs {
     static final AnnotationConfig PROFILE_QUICK_PERF_WITH_JMC = new AnnotationConfig.Builder()
             .testHasToBeLaunchedInASpecificJvm(QuickPerfProfilingAnnotToJvmOptionConverter.INSTANCE)
             .build(ProfileQuickPerfInTestJvm.class);
+
+    static final AnnotationConfig DISPLAY_RSS_FROM_PROCESS_STATUS = new AnnotationConfig.Builder()
+            .perfRecorderClass(ProcessStatusRecorder.class)
+            .perfIssueVerifier(MeasureRssPerfVerifier.INSTANCE)
+            .testHasToBeLaunchedInASpecificJvm()
+            .build(MeasureRSS.class);
+
+    static final AnnotationConfig MAX_RSS_FROM_PROCESS_STATUS = new AnnotationConfig.Builder()
+            .perfRecorderClass(ProcessStatusRecorder.class)
+            .perfIssueVerifier(ExpectRssPerfVerifier.INSTANCE)
+            .testHasToBeLaunchedInASpecificJvm()
+            .build(ExpectMaxRSS.class);
 
 }

--- a/jvm/jvm-annotations/src/main/java/org/quickperf/jvm/config/library/JvmConfigLoader.java
+++ b/jvm/jvm-annotations/src/main/java/org/quickperf/jvm/config/library/JvmConfigLoader.java
@@ -18,6 +18,7 @@ import org.quickperf.RecorderExecutionOrder;
 import org.quickperf.config.library.AnnotationConfig;
 import org.quickperf.jvm.allocation.bytewatcher.ByteWatcherRecorder;
 import org.quickperf.jvm.jfr.JfrEventsRecorder;
+import org.quickperf.jvm.rss.ProcessStatusRecorder;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -37,13 +38,16 @@ public class JvmConfigLoader implements QuickPerfConfigLoader {
                 , JvmAnnotationsConfigs.CHECK_JVM
                 , JvmAnnotationsConfigs.PROFILE_QUICK_PERF_WITH_JMC
                 , JvmAnnotationsConfigs.PROFILE_JVM_WITH_JFR
+                , JvmAnnotationsConfigs.DISPLAY_RSS_FROM_PROCESS_STATUS
+                , JvmAnnotationsConfigs.MAX_RSS_FROM_PROCESS_STATUS
         );
     }
 
     @Override
     public Collection<RecorderExecutionOrder> loadRecorderExecutionOrdersBeforeTestMethod() {
         return Arrays.asList(
-                  new RecorderExecutionOrder(JfrEventsRecorder.class, 6000)
+                  new RecorderExecutionOrder(ProcessStatusRecorder.class, 5070)
+                , new RecorderExecutionOrder(JfrEventsRecorder.class, 6000)
                 , new RecorderExecutionOrder(ByteWatcherRecorder.class, 6030)
         );
     }
@@ -53,6 +57,7 @@ public class JvmConfigLoader implements QuickPerfConfigLoader {
         return Arrays.asList(
                   new RecorderExecutionOrder(ByteWatcherRecorder.class, 3000)
                 , new RecorderExecutionOrder(JfrEventsRecorder.class, 3030)
+                , new RecorderExecutionOrder(ProcessStatusRecorder.class, 3060)
         );
     }
 

--- a/jvm/jvm-annotations/src/main/java/org/quickperf/jvm/rss/ExpectRssPerfVerifier.java
+++ b/jvm/jvm-annotations/src/main/java/org/quickperf/jvm/rss/ExpectRssPerfVerifier.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2020 the original author or authors.
+ */
+
+package org.quickperf.jvm.rss;
+
+import org.quickperf.issue.PerfIssue;
+import org.quickperf.issue.VerifiablePerformanceIssue;
+import org.quickperf.jvm.allocation.Allocation;
+import org.quickperf.jvm.allocation.AllocationUnit;
+import org.quickperf.jvm.allocation.ByteAllocationMeasureFormatter;
+import org.quickperf.jvm.annotations.ExpectMaxRSS;
+
+public class ExpectRssPerfVerifier implements VerifiablePerformanceIssue<ExpectMaxRSS, ProcessStatus> {
+
+    public static final VerifiablePerformanceIssue INSTANCE = new ExpectRssPerfVerifier();
+
+    private final ByteAllocationMeasureFormatter byteAllocationMeasureFormatter = ByteAllocationMeasureFormatter.INSTANCE;
+
+    private ExpectRssPerfVerifier() { }
+
+    @Override
+    public PerfIssue verifyPerfIssue(ExpectMaxRSS annotation, ProcessStatus processStatus) {
+
+        Allocation maxExpectedRss = new Allocation(annotation.value(), annotation.unit());
+        Allocation measuredRss = new Allocation((double) processStatus.getRssInKb() * 1024, AllocationUnit.BYTE);
+
+        if (maxExpectedRss.isLessThan(measuredRss)) {
+
+            String assertionMessage =
+                              "Expected RSS to be less than "
+                            + byteAllocationMeasureFormatter.format(maxExpectedRss)
+                            + " but is " + byteAllocationMeasureFormatter.format(measuredRss) + ".";
+            String description = assertionMessage + System.lineSeparator() + measuredRss.getComment();
+
+            return new PerfIssue(description);
+        }
+
+        return PerfIssue.NONE;
+
+    }
+}

--- a/jvm/jvm-annotations/src/main/java/org/quickperf/jvm/rss/MeasureRssPerfVerifier.java
+++ b/jvm/jvm-annotations/src/main/java/org/quickperf/jvm/rss/MeasureRssPerfVerifier.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2020 the original author or authors.
+ */
+
+package org.quickperf.jvm.rss;
+
+import org.quickperf.issue.PerfIssue;
+import org.quickperf.issue.VerifiablePerformanceIssue;
+import org.quickperf.jvm.annotations.MeasureRSS;
+
+public class MeasureRssPerfVerifier implements VerifiablePerformanceIssue<MeasureRSS, ProcessStatus> {
+    public static final VerifiablePerformanceIssue INSTANCE = new MeasureRssPerfVerifier();
+
+    private MeasureRssPerfVerifier(){
+    }
+
+    @Override
+    public PerfIssue verifyPerfIssue(MeasureRSS annotation, ProcessStatus measure) {
+        System.out.println("Measured RSS " + measure.getRssInKb() + " kb for process " + measure.getPid());
+        return PerfIssue.NONE;
+    }
+}

--- a/jvm/jvm-annotations/src/main/java/org/quickperf/jvm/rss/ProcessStatus.java
+++ b/jvm/jvm-annotations/src/main/java/org/quickperf/jvm/rss/ProcessStatus.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2020 the original author or authors.
+ */
+
+package org.quickperf.jvm.rss;
+
+import org.apache.commons.io.FileUtils;
+import org.quickperf.measure.AbstractComparablePerfMeasure;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.util.List;
+
+class ProcessStatus extends AbstractComparablePerfMeasure<ProcessStatus> {
+    private static ProcessStatus record;
+    private long rssInKb;
+    private String pid;
+
+    static void record(){
+        String statusFile = "/proc/self/status";
+        try {
+            List<String> status = FileUtils.readLines(new File(statusFile), "UTF-8");
+            ProcessStatus ps = new ProcessStatus();
+            //FIXME maybe use a regex instead of parsing all lines
+            for(String line : status){
+                if(line.startsWith("VmRSS")){
+                    String rss = line.substring(6, line.length() - 2).trim();
+                    ps.setRssInKb(Long.parseLong(rss));
+                }
+                if(line.startsWith("Pid")){
+                    String pid = line.substring(4).trim();
+                    ps.setPid(pid);
+                }
+            }
+            record = ps;
+        } catch (IOException e) {
+            System.out.println("[QUICK PERF] - ERROR - Unable to read the status file " + statusFile + " : status file are only available on Linux");
+        }
+    }
+
+    static ProcessStatus getRecord(){
+        return record;
+    }
+
+    static void reset(){
+        record = null;
+    }
+
+    public long getRssInKb() {
+        return rssInKb;
+    }
+
+    public void setRssInKb(long rssInKb) {
+        this.rssInKb = rssInKb;
+    }
+
+    public String getPid() {
+        return pid;
+    }
+
+    public void setPid(String pid) {
+        this.pid = pid;
+    }
+
+    @Override
+    public int compareTo(ProcessStatus processStatus) {
+        return 0;
+    }
+
+    @Override
+    public Object getValue() {
+        return record;
+    }
+
+    @Override
+    public Object getUnit() {
+        return "kb";
+    }
+
+    @Override
+    public String getComment() {
+        return null;
+    }
+}

--- a/jvm/jvm-annotations/src/main/java/org/quickperf/jvm/rss/ProcessStatusRecorder.java
+++ b/jvm/jvm-annotations/src/main/java/org/quickperf/jvm/rss/ProcessStatusRecorder.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2020 the original author or authors.
+ */
+
+package org.quickperf.jvm.rss;
+
+import org.quickperf.TestExecutionContext;
+import org.quickperf.perfrecording.RecordablePerformance;
+
+public class ProcessStatusRecorder implements RecordablePerformance<ProcessStatus> {
+    @Override
+    public void startRecording(TestExecutionContext testExecutionContext) {
+        //nothing to do : only record the process status at the end of the test
+    }
+
+    @Override
+    public void stopRecording(TestExecutionContext testExecutionContext) {
+        ProcessStatus.record();
+    }
+
+    @Override
+    public ProcessStatus findRecord(TestExecutionContext testExecutionContext) {
+        return ProcessStatus.getRecord();
+    }
+
+    @Override
+    public void cleanResources() {
+        ProcessStatus.reset();
+    }
+}


### PR DESCRIPTION
Fixes #21

This PR adds RSS annotations to measure the Resident Set Size of the process of the test methods.
This only works for Linux.

It adds the capability to gather process statistics so other annotations can take advantage of it.
It adds the capability from an anotation to skip the fork if needed.