### PR TITLE
feat: quarkus integration test

### DIFF
--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/SqlRecorderRegistry.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/SqlRecorderRegistry.java
@@ -24,7 +24,7 @@ public class SqlRecorderRegistry {
 
     private final Collection<SqlRecorder> sqlRecordersOfTestJvm = new ArrayList<>();
 
-    private static final ThreadLocal<Collection<SqlRecorder>> SQL_RECORDERS_WHEN_ONE_JVM = new ThreadLocal<Collection<SqlRecorder>>() {
+    private static final InheritableThreadLocal<Collection<SqlRecorder>> SQL_RECORDERS_WHEN_ONE_JVM = new InheritableThreadLocal<Collection<SqlRecorder>>() {
         @Override
         protected Collection<SqlRecorder> initialValue() {
             return new ArrayList<>();


### PR DESCRIPTION
Draft PR for Quarkus integration test.
It uses P6spy instead of a datasource proxy, we may implements more events if we keep it: https://github.com/p6spy/p6spy/blob/master/src/main/java/com/p6spy/engine/logging/LoggingEventListener.java

It cannot works with forks as forking the VM will implies launching Quarkus twice.

This is a draft PR to gather early feedback, please don't go into details now.