### PR TITLE
feat: make the resultset optional on the ExecutionInfo

### DIFF
--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/SqlExecution.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/SqlExecution.java
@@ -65,6 +65,10 @@ public class SqlExecution implements Externalizable {
 
     private long retrieveNumberOfReturnedColumns(ExecutionInfo executionInfo) {
         ResultSet resultSet = (ResultSet) executionInfo.getResult();
+        if(resultSet == null){
+            //FIXME this is needed for the prototype that uses P6spy
+            return 0;
+        }
         try {
             return resultSet.getMetaData().getColumnCount();
         } catch (SQLException e) {


### PR DESCRIPTION
This is needed for the prototype support of P6spy instead of ttddyy

This is needed for https://github.com/quick-perf/quickperf-examples/pull/4