### PR TITLE
Add @ExpectUpdatedColumn annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,15 @@ Many thanks to all our contributors!
             <br/>
             <a href="https://github.com/quick-perf/quickperf/commits?author=dialaya" title="Code">💻</a>
         </td>                
+        <td align="center">
+            <a href="https://github.com/fabfas">
+                <img src="https://avatars.githubusercontent.com/fabfas" width="100px;" alt="C Faisal"/>
+                <br/>
+                <sub><b>C Faisal</b></sub>
+            </a>
+            <br/>
+            <a href="https://github.com/quick-perf/quickperf/commits?author=fabfas" title="Code">💻</a>
+        </td>                
     </tr>
 </table>
 <a href = "https://allcontributors.org/docs/en/emoji-key">emoji key</a>

--- a/core/src/main/java/org/quickperf/unit/NoUnit.java
+++ b/core/src/main/java/org/quickperf/unit/NoUnit.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2020 the original author or authors.
+ */
+
+package org.quickperf.unit;
+
+public class NoUnit {
+
+    public static NoUnit INSTANCE = new NoUnit();
+
+    private NoUnit() { }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -350,6 +350,10 @@
             <name>Bakary Djiba</name>
             <url>https://github.com/dialaya</url>
         </contributor>
+        <contributor>
+            <name>C Faisal</name>
+            <url>https://github.com/fabfas</url>
+        </contributor>
     </contributors>
 
 </project>

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/SqlExecutions.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/SqlExecutions.java
@@ -17,6 +17,7 @@ import net.ttddyy.dsproxy.QueryType;
 import org.quickperf.issue.PerfIssue;
 import org.quickperf.issue.PerfIssuesFormat;
 import org.quickperf.perfrecording.ViewablePerfRecordIfPerfIssue;
+import org.quickperf.sql.update.columns.NumberOfUpdatedColumnsStatistics;
 
 import java.io.Serializable;
 import java.util.*;
@@ -69,20 +70,28 @@ public class SqlExecutions implements Iterable<SqlExecution>, ViewablePerfRecord
         return queryNumber;
     }
 
-    public long getMaxNumberOfUpdatedColumn() {
-        QueryTypeRetriever queryTypeRetriever = QueryTypeRetriever.INSTANCE;
-        long maxColumnCount = 0L;
+    public NumberOfUpdatedColumnsStatistics getUpdatedColumnsStatistics() {
+
+        long minColumnCount = 0;
+        long maxColumnCount = 0;
+
         for (SqlExecution sqlExecution : sqlExecutions) {
             for (QueryInfo query : sqlExecution.getQueries()) {
+                QueryTypeRetriever queryTypeRetriever = QueryTypeRetriever.INSTANCE;
                 if (queryTypeRetriever.typeOf(query) == QueryType.UPDATE) {
                     long updatedColumnCount = countUpdatedColumn(query.getQuery());
+                    if(minColumnCount == 0 || updatedColumnCount < minColumnCount) {
+                        minColumnCount = updatedColumnCount;
+                    }
                     if (updatedColumnCount > maxColumnCount) {
                         maxColumnCount = updatedColumnCount;
                     }
                 }
             }
         }
-        return maxColumnCount;
+
+        return new NumberOfUpdatedColumnsStatistics(minColumnCount, maxColumnCount);
+
     }
 
     private long countUpdatedColumn(String sql) {

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/annotation/ExpectUpdatedColumn.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/annotation/ExpectUpdatedColumn.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2020 the original author or authors.
+ */
+
+package org.quickperf.sql.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface ExpectUpdatedColumn {
+
+	int value() default 0;
+
+}

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/annotation/SqlAnnotationBuilder.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/annotation/SqlAnnotationBuilder.java
@@ -219,4 +219,16 @@ public class SqlAnnotationBuilder {
         };
     }
 
+    public static ExpectUpdatedColumn expectUpdatedColumn(final int value) {
+        return new ExpectUpdatedColumn() {
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return ExpectUpdatedColumn.class;
+            }
+            @Override
+            public int value() {
+                return value;
+            }
+        };
+    }
 }

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/config/library/SqlAnnotationsConfigs.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/config/library/SqlAnnotationsConfigs.java
@@ -37,6 +37,8 @@ import org.quickperf.sql.update.UpdateCountMeasureExtractor;
 import org.quickperf.sql.update.UpdateNumberPerfIssueVerifier;
 import org.quickperf.sql.update.columns.MaxUpdatedColumnsPerMeasureExtractor;
 import org.quickperf.sql.update.columns.MaxUpdatedColumnsPerfIssueVerifier;
+import org.quickperf.sql.update.columns.UpdatedColumnsMeasureExtractor;
+import org.quickperf.sql.update.columns.UpdatedColumnsPerfIssueVerifier;
 
 class SqlAnnotationsConfigs {
 
@@ -148,5 +150,11 @@ class SqlAnnotationsConfigs {
 			.perfMeasureExtractor(SqlQueryExecutionTimeExtractor.INSTANCE)
 			.perfIssueVerifier(SqlQueryMaxExecutionTimeVerifier.INSTANCE)
 			.build(ExpectMaxQueryExecutionTime.class);
+    
+    static final AnnotationConfig EXPECT_UPDATED_COLUMN = new AnnotationConfig.Builder()
+    		.perfRecorderClass(PersistenceSqlRecorder.class)
+    		.perfMeasureExtractor(UpdatedColumnsMeasureExtractor.INSTANCE)
+    		.perfIssueVerifier(UpdatedColumnsPerfIssueVerifier.INSTANCE)
+    		.build(ExpectUpdatedColumn.class);
 
 }

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/config/library/SqlConfigLoader.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/config/library/SqlConfigLoader.java
@@ -47,6 +47,7 @@ public class SqlConfigLoader implements QuickPerfConfigLoader {
                 , SqlAnnotationsConfigs.DISABLE_EXACTLY_SAME_SQL_SELECTS
                 , SqlAnnotationsConfigs.ENABLE_EXACTLY_SAME_SQL_SELECTS
                 , SqlAnnotationsConfigs.EXPECT_MAX_QUERY_EXECUTION_TIME
+                , SqlAnnotationsConfigs.EXPECT_UPDATED_COLUMN
         );
     }
 

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/update/columns/NumberOfUpdatedColumnsStatistics.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/update/columns/NumberOfUpdatedColumnsStatistics.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2020 the original author or authors.
+ */
+
+package org.quickperf.sql.update.columns;
+
+public class NumberOfUpdatedColumnsStatistics {
+
+    private final long minColumnCount;
+
+    private final long maxColumnCount;
+
+    public NumberOfUpdatedColumnsStatistics(long minColumnCount, long maxColumnCount) {
+        this.minColumnCount = minColumnCount;
+        this.maxColumnCount = maxColumnCount;
+    }
+
+    public long getMin() {
+        return minColumnCount;
+    }
+
+    public long getMax() {
+        return maxColumnCount;
+    }
+
+}

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/update/columns/NumberOfUpdatedColumnsStatisticsMeasure.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/update/columns/NumberOfUpdatedColumnsStatisticsMeasure.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2020 the original author or authors.
+ */
+
+package org.quickperf.sql.update.columns;
+
+import org.quickperf.measure.PerfMeasure;
+import org.quickperf.unit.NoUnit;
+
+public class NumberOfUpdatedColumnsStatisticsMeasure implements PerfMeasure<NumberOfUpdatedColumnsStatistics, NoUnit> {
+
+    private final NumberOfUpdatedColumnsStatistics numberOfUpdatedColumnsStatistics;
+
+    private final String comment;
+
+    public NumberOfUpdatedColumnsStatisticsMeasure(NumberOfUpdatedColumnsStatistics numberOfUpdatedColumnsStatistics
+                                                 , String comment) {
+        this.numberOfUpdatedColumnsStatistics = numberOfUpdatedColumnsStatistics;
+        this.comment = comment;
+    }
+
+    @Override
+    public NumberOfUpdatedColumnsStatistics getValue() {
+        return numberOfUpdatedColumnsStatistics;
+    }
+
+    @Override
+    public NoUnit getUnit() {
+        return NoUnit.INSTANCE;
+    }
+
+    @Override
+    public String getComment() {
+        return comment;
+    }
+
+}

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/update/columns/UpdatedColumnsMeasureExtractor.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/update/columns/UpdatedColumnsMeasureExtractor.java
@@ -13,19 +13,17 @@ package org.quickperf.sql.update.columns;
 
 import org.quickperf.ExtractablePerformanceMeasure;
 import org.quickperf.sql.SqlExecutions;
-import org.quickperf.unit.Count;
 
-public class MaxUpdatedColumnsPerMeasureExtractor implements ExtractablePerformanceMeasure<SqlExecutions, Count> {
+public class UpdatedColumnsMeasureExtractor implements ExtractablePerformanceMeasure<SqlExecutions, NumberOfUpdatedColumnsStatisticsMeasure> {
 
-    public static final MaxUpdatedColumnsPerMeasureExtractor INSTANCE = new MaxUpdatedColumnsPerMeasureExtractor();
+    public static final UpdatedColumnsMeasureExtractor INSTANCE = new UpdatedColumnsMeasureExtractor();
 
-    private MaxUpdatedColumnsPerMeasureExtractor() {}
+    private UpdatedColumnsMeasureExtractor() { }
 
     @Override
-    public Count extractPerfMeasureFrom(SqlExecutions perfRecord) {
-        NumberOfUpdatedColumnsStatistics updatedColumnsStatistics = perfRecord.getUpdatedColumnsStatistics();
-        long maxUpdatedColumns = updatedColumnsStatistics.getMax();
-        return new Count(maxUpdatedColumns);
+    public NumberOfUpdatedColumnsStatisticsMeasure extractPerfMeasureFrom(SqlExecutions sqlExecutions) {
+        return new NumberOfUpdatedColumnsStatisticsMeasure(sqlExecutions.getUpdatedColumnsStatistics()
+                                                         , sqlExecutions.toString());
     }
 
 }

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/update/columns/UpdatedColumnsPerfIssueVerifier.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/update/columns/UpdatedColumnsPerfIssueVerifier.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2020 the original author or authors.
+ */
+
+package org.quickperf.sql.update.columns;
+
+import org.quickperf.issue.PerfIssue;
+import org.quickperf.issue.VerifiablePerformanceIssue;
+import org.quickperf.sql.annotation.ExpectUpdatedColumn;
+
+public class UpdatedColumnsPerfIssueVerifier implements VerifiablePerformanceIssue<ExpectUpdatedColumn, NumberOfUpdatedColumnsStatisticsMeasure> {
+
+    public static final UpdatedColumnsPerfIssueVerifier INSTANCE = new UpdatedColumnsPerfIssueVerifier();
+
+    private UpdatedColumnsPerfIssueVerifier() {}
+
+    @Override
+    public PerfIssue verifyPerfIssue(ExpectUpdatedColumn annotation, NumberOfUpdatedColumnsStatisticsMeasure measure) {
+
+        NumberOfUpdatedColumnsStatistics updatedColumnsStatistics = measure.getValue();
+
+        int expectedUpdatesColumns = annotation.value();
+
+        long maxColumnCount = updatedColumnsStatistics.getMax();
+        long minColumnCount = updatedColumnsStatistics.getMin();
+
+        if(  expectedUpdatesColumns != minColumnCount || expectedUpdatesColumns != maxColumnCount
+          ) {
+            return buildPerfIssue(expectedUpdatesColumns, maxColumnCount, minColumnCount);
+        }
+
+        return PerfIssue.NONE;
+
+    }
+
+    private PerfIssue buildPerfIssue(int expectedUpdatesColumns, long maxColumnCount, long minColumnCount) {
+
+        String assertionMessage = "Expected number of updated columns "
+                                + "<" + expectedUpdatesColumns + ">";
+
+        boolean oneColumnUpdated = minColumnCount == maxColumnCount;
+        if(oneColumnUpdated) {
+            assertionMessage += " but is " + "<" + minColumnCount + ">" + ".";
+        } else {
+            assertionMessage += " but is between " + "<" + minColumnCount + ">"
+                              + " and " + "<" + maxColumnCount +  ">.";
+        }
+
+        return new PerfIssue(assertionMessage);
+
+    }
+
+}

--- a/sql/sql-integration-test/src/test/java/ExpectUpdatedColumnTest.java
+++ b/sql/sql-integration-test/src/test/java/ExpectUpdatedColumnTest.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2020 the original author or authors.
+ */
+
+import org.junit.Test;
+import org.junit.experimental.results.PrintableResult;
+import org.junit.runner.RunWith;
+import org.quickperf.junit4.QuickPerfJUnitRunner;
+import org.quickperf.sql.annotation.ExpectUpdatedColumn;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExpectUpdatedColumnTest {
+
+    @RunWith(QuickPerfJUnitRunner.class)
+    @ExpectUpdatedColumn(2)
+    public static class AClassAnnotatedWithExpectUpdatedColumnPassing extends SqlTestBase {
+
+        @Test
+        public void execute_update_with_two_columns_updated_and_a_where_clause() {
+            EntityManager em = emf.createEntityManager();
+            em.getTransaction().begin();
+            Query nativeQuery = em.createNativeQuery("UPDATE book SET isbn = :isbn, title = :title WHERE id = :id")
+                               .setParameter("isbn", 12)
+                               .setParameter("title", "Manon")
+                               .setParameter("id", 40);
+            nativeQuery.executeUpdate();
+            em.getTransaction().commit();
+        }
+
+    }
+
+    @Test public void
+    should_pass_if_the_number_of_sql_updates_is_equal_to_the_number_expected_with_annotation_on_method() {
+
+        // GIVEN
+        Class<?> testClass = AClassAnnotatedWithExpectUpdatedColumnPassing.class;
+
+        // WHEN
+        PrintableResult printableResult = PrintableResult.testResult(testClass);
+
+        // THEN
+        assertThat(printableResult.failureCount()).isZero();
+
+    }
+
+    @RunWith(QuickPerfJUnitRunner.class)
+    @ExpectUpdatedColumn(1)
+    public static class AClassAnnotatedWithExpectUpdatedColumnFailing extends SqlTestBase {
+
+        @Test
+        public void execute_update_with_two_columns_updated() {
+            EntityManager em = emf.createEntityManager();
+            em.getTransaction().begin();
+            Query nativeQuery = em.createNativeQuery("UPDATE book SET isbn = :isbn, title = :title")
+                               .setParameter("isbn", 12)
+                               .setParameter("title", "Manon");
+            nativeQuery.executeUpdate();
+            em.getTransaction().commit();
+        }
+
+    }
+
+    @Test public void
+    should_fail_if_the_number_of_sql_updates_is_not_equal_the_number_expected_with_annotation_on_method() {
+
+        // GIVEN
+        Class<?> testClass = AClassAnnotatedWithExpectUpdatedColumnFailing.class;
+
+        // WHEN
+        PrintableResult printableResult = PrintableResult.testResult(testClass);
+
+        // THEN
+        assertThat(printableResult.failureCount()).isOne();
+
+        assertThat(printableResult.toString()).contains(
+                "Expected number of updated columns <1> but is <2>.");
+
+        assertThat(printableResult.toString().toLowerCase())
+                      .contains("update")
+                      .contains("book")
+                      .contains("set")
+                      .contains("isbn = ?")
+                      .contains("title = ?");
+
+    }
+
+    @RunWith(QuickPerfJUnitRunner.class)
+    @ExpectUpdatedColumn(2)
+    public static class AClassAnnotatedWithExpectUpdatedColumnFailingBecauseOneOfTheTwoUpdates extends SqlTestBase {
+
+        @Test
+        public void execute_two_update_statements() {
+
+            EntityManager em = emf.createEntityManager();
+            em.getTransaction().begin();
+
+            // Two updated columns
+            Query nativeQuery1 = em.createNativeQuery("UPDATE book SET isbn = :isbn, title = :title WHERE id = :id")
+                                 .setParameter("isbn", 12)
+                                 .setParameter("title", "Manon")
+                                 .setParameter("id", 40);
+            nativeQuery1.executeUpdate();
+
+            // One updated column
+            Query nativeQuery2 = em.createNativeQuery("UPDATE book SET isbn = :isbn WHERE id = :id")
+                                .setParameter("isbn", 12)
+                                .setParameter("id", 41);
+            nativeQuery2.executeUpdate();
+
+            em.getTransaction().commit();
+
+        }
+
+    }
+
+    @Test public void
+    should_fail_if_one_of_the_statements_updates_a_number_of_columns_different_from_this_expected() {
+
+        // GIVEN
+        Class<?> testClass = AClassAnnotatedWithExpectUpdatedColumnFailingBecauseOneOfTheTwoUpdates.class;
+
+        // WHEN
+        PrintableResult printableResult = PrintableResult.testResult(testClass);
+
+        // THEN
+        assertThat(printableResult.failureCount()).isOne();
+
+        assertThat(printableResult.toString()).contains(
+                "Expected number of updated columns <2> but is between <1> and <2>.");
+
+        assertThat(printableResult.toString())
+                .containsIgnoringCase("id = ?\"], Params:[(12,Manon,40)]")
+                .contains("id = ?\"], Params:[(12,41)]");
+
+    }
+
+}
+


### PR DESCRIPTION
I have tried following the [instructions][1]. The main changes include:

- Added the @ExpectUpdatedColumn annotation
- Added  `UpdatedColumnsMeasureExtractor` and `UpdatedColumnsPerfIssueVerifier` classes in the package `org/quickperf/sql/update/columns`
- The updated columns count getting from the exisitng method.
- Added the unit test

[1]: here:https://github.com/quick-perf/doc/wiki/Create-an-annotation#steps-to-follow-to-add-a-sql-annotation-to-quickperf