### PR TITLE
Work on measure heap allocation report

### DIFF
--- a/jvm/jvm-annotations/src/main/java/org/quickperf/jvm/allocation/MeasureHeapAllocationPerfVerifier.java
+++ b/jvm/jvm-annotations/src/main/java/org/quickperf/jvm/allocation/MeasureHeapAllocationPerfVerifier.java
@@ -28,9 +28,11 @@ public class MeasureHeapAllocationPerfVerifier implements VerifiablePerformanceI
     @Override
     public PerfIssue verifyPerfIssue(MeasureHeapAllocation annotation, Allocation measuredAllocation) {
         String allocationAsString = byteAllocationMeasureFormatter.format(measuredAllocation);
-        try (PrintWriter pw = new PrintWriter(System.out);) {
-            pw.printf(annotation.format(), allocationAsString);
-        }
+        PrintWriter pw = new PrintWriter(System.out);
+        pw.printf(annotation.format(), allocationAsString);
+        // do not call close on pw since it will call close on System.out
+        // thus preventing any further printing on the console
+        pw.flush();
         return PerfIssue.NONE;
     }
 

--- a/jvm/jvm-annotations/src/main/java/org/quickperf/jvm/allocation/MeasureHeapAllocationPerfVerifier.java
+++ b/jvm/jvm-annotations/src/main/java/org/quickperf/jvm/allocation/MeasureHeapAllocationPerfVerifier.java
@@ -15,6 +15,8 @@ import org.quickperf.issue.PerfIssue;
 import org.quickperf.issue.VerifiablePerformanceIssue;
 import org.quickperf.jvm.annotations.MeasureHeapAllocation;
 
+import java.io.PrintWriter;
+
 public class MeasureHeapAllocationPerfVerifier implements VerifiablePerformanceIssue<MeasureHeapAllocation, Allocation> {
 
     public static final VerifiablePerformanceIssue INSTANCE = new MeasureHeapAllocationPerfVerifier();
@@ -26,7 +28,8 @@ public class MeasureHeapAllocationPerfVerifier implements VerifiablePerformanceI
     @Override
     public PerfIssue verifyPerfIssue(MeasureHeapAllocation annotation, Allocation measuredAllocation) {
         String allocationAsString = byteAllocationMeasureFormatter.format(measuredAllocation);
-        System.out.println("[QUICK PERF] Measured heap allocation (test method thread): " + allocationAsString);
+        PrintWriter pw = new PrintWriter(System.out);
+        pw.printf(annotation.format(), allocationAsString);
         return PerfIssue.NONE;
     }
 

--- a/jvm/jvm-annotations/src/main/java/org/quickperf/jvm/allocation/MeasureHeapAllocationPerfVerifier.java
+++ b/jvm/jvm-annotations/src/main/java/org/quickperf/jvm/allocation/MeasureHeapAllocationPerfVerifier.java
@@ -28,8 +28,9 @@ public class MeasureHeapAllocationPerfVerifier implements VerifiablePerformanceI
     @Override
     public PerfIssue verifyPerfIssue(MeasureHeapAllocation annotation, Allocation measuredAllocation) {
         String allocationAsString = byteAllocationMeasureFormatter.format(measuredAllocation);
-        PrintWriter pw = new PrintWriter(System.out);
-        pw.printf(annotation.format(), allocationAsString);
+        try (PrintWriter pw = new PrintWriter(System.out);) {
+            pw.printf(annotation.format(), allocationAsString);
+        }
         return PerfIssue.NONE;
     }
 

--- a/jvm/jvm-annotations/src/main/java/org/quickperf/jvm/annotations/JvmAnnotationBuilder.java
+++ b/jvm/jvm-annotations/src/main/java/org/quickperf/jvm/annotations/JvmAnnotationBuilder.java
@@ -95,6 +95,11 @@ public class JvmAnnotationBuilder {
     public static MeasureHeapAllocation measureHeapAllocation() {
         return new MeasureHeapAllocation() {
             @Override
+            public String format() {
+                return "[QUICK PERF] Measured heap allocation (test method thread): %s\n";
+            }
+
+            @Override
             public Class<? extends Annotation> annotationType() {
                 return MeasureHeapAllocation.class;
             }

--- a/jvm/jvm-annotations/src/main/java/org/quickperf/jvm/annotations/MeasureHeapAllocation.java
+++ b/jvm/jvm-annotations/src/main/java/org/quickperf/jvm/annotations/MeasureHeapAllocation.java
@@ -20,4 +20,14 @@ import java.lang.annotation.Target;
 @Target({ElementType.METHOD, ElementType.TYPE})
 public @interface MeasureHeapAllocation {
 
+    /**
+     * Provides the format used to print the measured heap allocation on the console. This format
+     * will be called with a preformatted allocation as a String. So the only element you can
+     * use in this format is <code>%s</code>.
+     *
+     * The default value is <code>[QUICK PERF] Measured heap allocation (test method thread): %s</code>
+     *
+     * @return
+     */
+    String format() default "[QUICK PERF] Measured heap allocation (test method thread): %s\n";
 }


### PR DESCRIPTION
Hello, 
I added the possibility to pass a format as an attribute to the MeasureHeapAllocation annotation. 
The format is used to format the amount of memory formatted as a String by QuickPerf. 
The default format correspond to the one used in the current version of QuickPerf, to the existing code continues to work as it did previously. 
Writing a test can be done in the following: 
@Test @MeasureHeapAllocation(format = "Memory consumed: %s\n")
public void array_list() {
    // some critical stuff here!
}
The result would be: 
Memory consumed: 314.0 bytes
-- José