### PR TITLE
add configurable verbosity

### DIFF
--- a/core/src/main/java/org/quickperf/SystemProperties.java
+++ b/core/src/main/java/org/quickperf/SystemProperties.java
@@ -64,4 +64,38 @@ public class SystemProperties {
                     return "-D" + name + "=" + propertyValue;
                 }
             };
+
+    public static final SystemProperty<Boolean> SIMPLIFIED_SQL_DISPLAY =
+            new SystemProperty<Boolean>() {
+
+                private final String name = "limitQuickPerfSqlInfoOnConsole";
+
+                @Override
+                public Boolean evaluate() {
+                    String booleanAsString = System.getProperty(name);
+                    return Boolean.valueOf(booleanAsString);
+                }
+
+                @Override
+                public String buildForJvm(String propertyValue) {
+                    return "-D" + name + "=" + propertyValue;
+                }
+            };
+
+    public static final SystemProperty<Boolean> SIMPLIFIED_JVM_PROFILE_DISPLAY =
+            new SystemProperty<Boolean>() {
+
+                private final String name = "limitQuickPerfJvmInfoOnConsole";
+
+                @Override
+                public Boolean evaluate() {
+                    String booleanAsString = System.getProperty(name);
+                    return Boolean.valueOf(booleanAsString);
+                }
+
+                @Override
+                public String buildForJvm(String propertyValue) {
+                    return "-D" + name + "=" + propertyValue;
+                }
+            };
 }

--- a/jvm/jfr-annotations/src/main/java/org/quickperf/jvm/jmc/value/DisplayJvmProfilingValueVerifier.java
+++ b/jvm/jfr-annotations/src/main/java/org/quickperf/jvm/jmc/value/DisplayJvmProfilingValueVerifier.java
@@ -15,6 +15,7 @@ import org.openjdk.jmc.common.item.IItemCollection;
 import org.openjdk.jmc.common.item.IItemFilter;
 import org.openjdk.jmc.common.item.IItemIterable;
 import org.openjdk.jmc.common.item.ItemFilters;
+import org.quickperf.SystemProperties;
 import org.quickperf.issue.PerfIssue;
 import org.quickperf.issue.VerifiablePerformanceIssue;
 import org.quickperf.jvm.annotations.ProfileJvm;
@@ -37,78 +38,81 @@ public class DisplayJvmProfilingValueVerifier implements
     @Override
     public PerfIssue verifyPerfIssue(ProfileJvm annotation, JfrEventsMeasure jfrEventsMeasure) {
 
-        IItemCollection jfrEvents = jfrEventsMeasure.getValue();
+        if(!SystemProperties.SIMPLIFIED_JVM_PROFILE_DISPLAY.evaluate()) {
 
-        System.out.println();
+            IItemCollection jfrEvents = jfrEventsMeasure.getValue();
 
-        String allocationTotal = ALLOCATION_TOTAL.formatAsString(jfrEvents);
-        String insideTlabSum = ALLOC_INSIDE_TLAB_SUM.formatAsString(jfrEvents);
-        String outsideTlabSum = ALLOC_OUTSIDE_TLAB_SUM.formatAsString(jfrEvents);
-        String allocationRate = ALLOCATION_RATE.formatAsString(jfrEvents);
+            String allocationTotal = ALLOCATION_TOTAL.formatAsString(jfrEvents);
+            String insideTlabSum = ALLOC_INSIDE_TLAB_SUM.formatAsString(jfrEvents);
+            String outsideTlabSum = ALLOC_OUTSIDE_TLAB_SUM.formatAsString(jfrEvents);
+            String allocationRate = ALLOCATION_RATE.formatAsString(jfrEvents);
 
-        String totalGcPause = TOTAL_GC_PAUSE.formatAsString(jfrEvents);
-        String gcPause = LONGEST_GC_PAUSE.formatAsString(jfrEvents);
-        String oldGcCollection = String.valueOf(getOldGcCount(jfrEvents));
-        String youngGcCollection = String.valueOf(getYoungGcCount(jfrEvents));
+            String totalGcPause = TOTAL_GC_PAUSE.formatAsString(jfrEvents);
+            String gcPause = LONGEST_GC_PAUSE.formatAsString(jfrEvents);
+            String oldGcCollection = String.valueOf(getOldGcCount(jfrEvents));
+            String youngGcCollection = String.valueOf(getYoungGcCount(jfrEvents));
 
-        String exceptionsCount = EXCEPTIONS_COUNT.formatAsString(jfrEvents);
+            String exceptionsCount = EXCEPTIONS_COUNT.formatAsString(jfrEvents);
 
-        String longestCompilation = LONGEST_COMPILATION.formatAsString(jfrEvents);
+            String longestCompilation = LONGEST_COMPILATION.formatAsString(jfrEvents);
 
-        String errorCount = ERROR_COUNT.formatAsString(jfrEvents);
-        String throwablesCount = THROWABLES_COUNT.formatAsString(jfrEvents);
+            String errorCount = ERROR_COUNT.formatAsString(jfrEvents);
+            String throwablesCount = THROWABLES_COUNT.formatAsString(jfrEvents);
 
-        String compilationsCount = COMPILATIONS_COUNT.formatAsString(jfrEvents);
-        String codeCacheFullCount = CODE_CACHE_FULL_COUNT.getLabel() + ": " + CODE_CACHE_FULL_COUNT.formatAsString(jfrEvents);
+            String compilationsCount = COMPILATIONS_COUNT.formatAsString(jfrEvents);
+            String codeCacheFullCount = CODE_CACHE_FULL_COUNT.getLabel() + ": " + CODE_CACHE_FULL_COUNT.formatAsString(jfrEvents);
 
-        String jvmName = JVM_NAME.formatAsString(jfrEvents);
-        String jvmVersion = JVM_VERSION.formatAsString(jfrEvents);
-        String jvmArguments = JVM_ARGUMENTS.formatAsString(jfrEvents);
+            String jvmName = JVM_NAME.formatAsString(jfrEvents);
+            String jvmVersion = JVM_VERSION.formatAsString(jfrEvents);
+            String jvmArguments = JVM_ARGUMENTS.formatAsString(jfrEvents);
 
-        String minHwThreads = MIN_HW_THREADS.formatAsString(jfrEvents);
-        String minNumberOfCores = MIN_NUMBER_OF_CORES.formatAsString(jfrEvents);
-        String minNumberOfSockets = MIN_NUMBER_OF_SOCKETS.formatAsString(jfrEvents);
-        String cpuDescription = CPU_DESCRIPTION.formatAsString(jfrEvents);
+            String minHwThreads = MIN_HW_THREADS.formatAsString(jfrEvents);
+            String minNumberOfCores = MIN_NUMBER_OF_CORES.formatAsString(jfrEvents);
+            String minNumberOfSockets = MIN_NUMBER_OF_SOCKETS.formatAsString(jfrEvents);
+            String cpuDescription = CPU_DESCRIPTION.formatAsString(jfrEvents);
 
-        String osVersion = OS_VERSION.formatAsString(jfrEvents);
+            String osVersion = OS_VERSION.formatAsString(jfrEvents);
 
-        StringWidthAdapter twelveLength = new StringWidthAdapter(12);
+            StringWidthAdapter twelveLength = new StringWidthAdapter(12);
 
-        StringWidthAdapter fifteenLength = new StringWidthAdapter(15);
+            StringWidthAdapter fifteenLength = new StringWidthAdapter(15);
 
-        StringWidthAdapter twentyNineLength = new StringWidthAdapter(29);
+            StringWidthAdapter twentyNineLength = new StringWidthAdapter(29);
 
-        StringWidthAdapter thirtyLength = new StringWidthAdapter(30);
+            StringWidthAdapter thirtyLength = new StringWidthAdapter(30);
 
-        String text =
-            LINE
-            + " ALLOCATION (estimations)"                           + "     |   " + "GARBAGE COLLECTION           "                             + "|  THROWABLE" + LINE_SEPARATOR
-            + " Total       : " + fifteenLength.adapt(allocationTotal)   + "|   " + twentyNineLength.adapt("Total pause     : " + totalGcPause) + "|  Exception: " + exceptionsCount + LINE_SEPARATOR
-            + " Inside TLAB : " + fifteenLength.adapt(insideTlabSum)     + "|   " + twentyNineLength.adapt("Longest GC pause: " + gcPause)      + "|  Error    : " + errorCount + LINE_SEPARATOR
-            + " Outside TLAB: " + fifteenLength.adapt(outsideTlabSum)    + "|   " + twentyNineLength.adapt("Young: " + youngGcCollection)       + "|  Throwable: " + throwablesCount + LINE_SEPARATOR
-            + " Allocation rate: " + twelveLength.adapt(allocationRate)  + "|   " + twentyNineLength.adapt("Old  : " + oldGcCollection)         + "|" + LINE_SEPARATOR
-            + LINE
-            + thirtyLength.adapt(" COMPILATION")                    + "|   " + "CODE CACHE" + LINE_SEPARATOR
-            + thirtyLength.adapt(" Number : " + compilationsCount)  + "|   " + codeCacheFullCount + LINE_SEPARATOR
-            + thirtyLength.adapt(" Longest: " + longestCompilation) + "|   " + LINE_SEPARATOR
-            + LINE
-            + " " + "JVM" + LINE_SEPARATOR
-            + " Name     : " + jvmName      + LINE_SEPARATOR
-            + " Version  : " + jvmVersion   + LINE_SEPARATOR
-            + " Arguments: " + jvmArguments + LINE_SEPARATOR
-            + LINE
-            + " " + "HARDWARE" + LINE_SEPARATOR
-            + " Hardware threads: " + minHwThreads       + LINE_SEPARATOR
-            + " Cores           : " + minNumberOfCores   + LINE_SEPARATOR
-            + " Sockets         : " + minNumberOfSockets + LINE_SEPARATOR
-            + " CPU" + LINE_SEPARATOR
-            + cpuDescription + LINE_SEPARATOR
-            + LINE
-            + " OS" + LINE_SEPARATOR
-            + osVersion + LINE_SEPARATOR
-            + LINE;
-      
-        System.out.println(text);
+            String text =
+                LINE_SEPARATOR
+                + LINE
+                + " ALLOCATION (estimations)"                           + "     |   " + "GARBAGE COLLECTION           "                             + "|  THROWABLE" + LINE_SEPARATOR
+                + " Total       : " + fifteenLength.adapt(allocationTotal)   + "|   " + twentyNineLength.adapt("Total pause     : " + totalGcPause) + "|  Exception: " + exceptionsCount + LINE_SEPARATOR
+                + " Inside TLAB : " + fifteenLength.adapt(insideTlabSum)     + "|   " + twentyNineLength.adapt("Longest GC pause: " + gcPause)      + "|  Error    : " + errorCount + LINE_SEPARATOR
+                + " Outside TLAB: " + fifteenLength.adapt(outsideTlabSum)    + "|   " + twentyNineLength.adapt("Young: " + youngGcCollection)       + "|  Throwable: " + throwablesCount + LINE_SEPARATOR
+                + " Allocation rate: " + twelveLength.adapt(allocationRate)  + "|   " + twentyNineLength.adapt("Old  : " + oldGcCollection)         + "|" + LINE_SEPARATOR
+                + LINE
+                + thirtyLength.adapt(" COMPILATION")                    + "|   " + "CODE CACHE" + LINE_SEPARATOR
+                + thirtyLength.adapt(" Number : " + compilationsCount)  + "|   " + codeCacheFullCount + LINE_SEPARATOR
+                + thirtyLength.adapt(" Longest: " + longestCompilation) + "|   " + LINE_SEPARATOR
+                + LINE
+                + " " + "JVM" + LINE_SEPARATOR
+                + " Name     : " + jvmName      + LINE_SEPARATOR
+                + " Version  : " + jvmVersion   + LINE_SEPARATOR
+                + " Arguments: " + jvmArguments + LINE_SEPARATOR
+                + LINE
+                + " " + "HARDWARE" + LINE_SEPARATOR
+                + " Hardware threads: " + minHwThreads       + LINE_SEPARATOR
+                + " Cores           : " + minNumberOfCores   + LINE_SEPARATOR
+                + " Sockets         : " + minNumberOfSockets + LINE_SEPARATOR
+                + " CPU" + LINE_SEPARATOR
+                + cpuDescription + LINE_SEPARATOR
+                + LINE
+                + " OS" + LINE_SEPARATOR
+                + osVersion + LINE_SEPARATOR
+                + LINE;
+
+            System.out.println(text);
+
+        }
 
         return PerfIssue.NONE;
 

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/SqlExecutions.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/SqlExecutions.java
@@ -14,6 +14,7 @@ package org.quickperf.sql;
 import net.ttddyy.dsproxy.ExecutionInfo;
 import net.ttddyy.dsproxy.QueryInfo;
 import net.ttddyy.dsproxy.QueryType;
+import org.quickperf.SystemProperties;
 import org.quickperf.issue.PerfIssue;
 import org.quickperf.issue.PerfIssuesFormat;
 import org.quickperf.perfrecording.ViewablePerfRecordIfPerfIssue;
@@ -137,6 +138,11 @@ public class SqlExecutions implements Iterable<SqlExecution>, ViewablePerfRecord
     @Override
     public String format(Collection<PerfIssue> perfIssues) {
         String standardFormatting = PerfIssuesFormat.STANDARD.format(perfIssues);
+
+        if(SystemProperties.SIMPLIFIED_SQL_DISPLAY.evaluate()) {
+            return standardFormatting;
+        }
+
         return standardFormatting
                 + System.lineSeparator()
                 + System.lineSeparator()

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/delete/MaxOfDeletesPerfIssueVerifier.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/delete/MaxOfDeletesPerfIssueVerifier.java
@@ -11,6 +11,7 @@
 
 package org.quickperf.sql.delete;
 
+import org.quickperf.SystemProperties;
 import org.quickperf.issue.PerfIssue;
 import org.quickperf.issue.VerifiablePerformanceIssue;
 import org.quickperf.sql.annotation.ExpectMaxDelete;
@@ -47,7 +48,7 @@ public class MaxOfDeletesPerfIssueVerifier implements VerifiablePerformanceIssue
                            + System.lineSeparator()
                            ;
 
-        if(!expectedCount.isEqualTo(Count.ZERO)) {
+        if(!SystemProperties.SIMPLIFIED_SQL_DISPLAY.evaluate() && !expectedCount.isEqualTo(Count.ZERO)) {
             description += JdbcSuggestion.BATCHING.getMessage();
         }
 

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/insert/MaxOfInsertsPerfIssueVerifier.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/insert/MaxOfInsertsPerfIssueVerifier.java
@@ -11,6 +11,7 @@
 
 package org.quickperf.sql.insert;
 
+import org.quickperf.SystemProperties;
 import org.quickperf.issue.PerfIssue;
 import org.quickperf.issue.VerifiablePerformanceIssue;
 import org.quickperf.sql.annotation.ExpectMaxInsert;
@@ -47,7 +48,7 @@ public class MaxOfInsertsPerfIssueVerifier implements VerifiablePerformanceIssue
                            + System.lineSeparator()
                            ;
 
-        if(!expectedCount.isEqualTo(Count.ZERO)) {
+        if(!SystemProperties.SIMPLIFIED_SQL_DISPLAY.evaluate() && !expectedCount.isEqualTo(Count.ZERO)) {
             description += JdbcSuggestion.BATCHING.getMessage();
         }
 

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/select/HasSameSelectTypesWithDiffParamValuesVerifier.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/select/HasSameSelectTypesWithDiffParamValuesVerifier.java
@@ -11,6 +11,7 @@
 
 package org.quickperf.sql.select;
 
+import org.quickperf.SystemProperties;
 import org.quickperf.issue.PerfIssue;
 import org.quickperf.issue.VerifiablePerformanceIssue;
 import org.quickperf.sql.annotation.DisableSameSelectTypesWithDifferentParamValues;
@@ -31,9 +32,14 @@ public class HasSameSelectTypesWithDiffParamValuesVerifier implements Verifiable
                 selectAnalysis.getSameSelectTypesWithDifferentParamValues();
 
         if(sameSelectTypesWithDifferentParamValues.evaluate()) {
-            String description =  "Same SELECT types with different parameter values"
-                                + sameSelectTypesWithDifferentParamValues.getSuggestionToFixIt();
+            String description =  "Same SELECT types with different parameter values";
+
+            if(!SystemProperties.SIMPLIFIED_SQL_DISPLAY.evaluate()){
+                description += sameSelectTypesWithDifferentParamValues.getSuggestionToFixIt();
+            }
+
             return new PerfIssue(description);
+
         }
 
         return PerfIssue.NONE;

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/select/MaxOfSelectsPerfIssueVerifier.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/select/MaxOfSelectsPerfIssueVerifier.java
@@ -11,6 +11,7 @@
 
 package org.quickperf.sql.select;
 
+import org.quickperf.SystemProperties;
 import org.quickperf.issue.PerfIssue;
 import org.quickperf.issue.VerifiablePerformanceIssue;
 import org.quickperf.sql.annotation.ExpectMaxSelect;
@@ -46,7 +47,7 @@ public class MaxOfSelectsPerfIssueVerifier implements VerifiablePerformanceIssue
         SameSelectTypesWithDifferentParamValues sameSelectTypesWithDifferentParamValues =
                 selectAnalysis.getSameSelectTypesWithDifferentParamValues();
 
-        if (sameSelectTypesWithDifferentParamValues.evaluate()) {
+        if (!SystemProperties.SIMPLIFIED_SQL_DISPLAY.evaluate() && sameSelectTypesWithDifferentParamValues.evaluate()) {
             description += sameSelectTypesWithDifferentParamValues.getSuggestionToFixIt();
         }
 

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/select/SelectNumberPerfIssueVerifier.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/select/SelectNumberPerfIssueVerifier.java
@@ -11,6 +11,7 @@
 
 package org.quickperf.sql.select;
 
+import org.quickperf.SystemProperties;
 import org.quickperf.issue.PerfIssue;
 import org.quickperf.issue.VerifiablePerformanceIssue;
 import org.quickperf.sql.annotation.ExpectSelect;
@@ -46,7 +47,7 @@ public class SelectNumberPerfIssueVerifier implements VerifiablePerformanceIssue
         SameSelectTypesWithDifferentParamValues sameSelectTypesWithDifferentParamValues =
                 selectAnalysis.getSameSelectTypesWithDifferentParamValues();
 
-        if(   executedSelectNumber.isGreaterThan(expectedSelectNumber)
+        if( !SystemProperties.SIMPLIFIED_SQL_DISPLAY.evaluate() && executedSelectNumber.isGreaterThan(expectedSelectNumber)
            && sameSelectTypesWithDifferentParamValues.evaluate()
           ) {
             description += sameSelectTypesWithDifferentParamValues.getSuggestionToFixIt();

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/update/MaxOfUpdatesPerfIssueVerifier.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/update/MaxOfUpdatesPerfIssueVerifier.java
@@ -11,6 +11,7 @@
 
 package org.quickperf.sql.update;
 
+import org.quickperf.SystemProperties;
 import org.quickperf.issue.PerfIssue;
 import org.quickperf.issue.VerifiablePerformanceIssue;
 import org.quickperf.sql.annotation.ExpectMaxUpdate;
@@ -45,7 +46,7 @@ public class MaxOfUpdatesPerfIssueVerifier implements VerifiablePerformanceIssue
                 + System.lineSeparator()
                 + System.lineSeparator();
 
-        if(!expectedCount.isEqualTo(Count.ZERO)) {
+        if(!SystemProperties.SIMPLIFIED_SQL_DISPLAY.evaluate() && !expectedCount.isEqualTo(Count.ZERO)) {
             description += JdbcSuggestion.BATCHING.getMessage();
         }
 


### PR DESCRIPTION
See issue #84 for feature's background:

This feature aims to reduce verbosity of some of QuickPerf feedbacks. Configurable verbosity has been added for the following annotations:
- @[ProfileJvm](https://github.com/quick-perf/doc/wiki/JVM-annotations#profilejvm) annotation with JVM boolean option `-DlimitQuickPerfJvmInfoOnConsole`.
The only information displayed on the console will be the location of the file generated by the Java Flight Recorder when JVM option set to true.

- [SQL annotations](https://github.com/quick-perf/doc/wiki/SQL-annotations) involving JDBC roundtrips (@ExpectMaxUpdate, @ExpectMaxDelete, @ExpectMaxInsert, @ExpectMaxSelect and @ExpectSelect) and @DisableSameSelectTypesWithDifferentParamValues. 
Framework, JDBC batching suggestions and details of the executed queries will not be displayed when JVM option `-DlimitQuickPerfSqlInfoOnConsole` is set to true.