### PR TITLE
Support JUnit5 test template

### DIFF
--- a/core/src/main/java/org/quickperf/TestExecutionContext.java
+++ b/core/src/main/java/org/quickperf/TestExecutionContext.java
@@ -286,5 +286,8 @@ public class TestExecutionContext {
         }
     }
 
+    public void setRunnerAllocationOffset(int runnerAllocationOffset) {
+        this.runnerAllocationOffset = runnerAllocationOffset;
+    }
 }
 

--- a/junit5/junit5-jvm-test/src/test/java/org/quickperf/junit5/jvm/testtemplate/AllocationJUnit5TestTemplateTest.java
+++ b/junit5/junit5-jvm-test/src/test/java/org/quickperf/junit5/jvm/testtemplate/AllocationJUnit5TestTemplateTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2020 the original author or authors.
+ */
+
+package org.quickperf.junit5.jvm.testtemplate;
+
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.quickperf.junit5.JUnit5Tests;
+import org.quickperf.junit5.JUnit5Tests.JUnit5TestsResult;
+import org.quickperf.junit5.QuickPerfTest;
+import org.quickperf.jvm.allocation.AllocationUnit;
+import org.quickperf.jvm.annotations.ExpectMaxHeapAllocation;
+import org.quickperf.jvm.annotations.ExpectNoHeapAllocation;
+import org.quickperf.jvm.annotations.JvmOptions;
+import org.quickperf.jvm.annotations.MeasureHeapAllocation;
+
+import java.util.ArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AllocationJUnit5TestTemplateTest {
+
+    @QuickPerfTest
+    public static class ClassWithMethodAnnotatedWithExpectMaxHeapAllocation {
+
+        @ExpectMaxHeapAllocation(value = 439, unit = AllocationUnit.BYTE)
+        // See ClassWithMethodAnnotatedWithMeasureHeapAllocation
+        @JvmOptions("-XX:+UseCompressedOops -XX:+UseCompressedClassPointers")
+        @RepeatedTest(2)
+        public void array_list_with_size_100_should_allocate_440_bytes() {
+            ArrayList<Object> data = new ArrayList<>(100);
+        }
+
+    }
+
+    @Test public void
+    test_should_fail_if_allocation_is_greater_than_expected() {
+
+        // GIVEN
+        Class<?> testClass = ClassWithMethodAnnotatedWithExpectMaxHeapAllocation.class;
+        JUnit5Tests jUnit5Tests = JUnit5Tests.createInstance(testClass);
+
+        // WHEN
+        JUnit5TestsResult jUnit5TestsResult = jUnit5Tests.run();
+
+        // THEN
+        assertThat(jUnit5TestsResult.getNumberOfFailures()).isEqualTo(2);
+
+        String errorReport = jUnit5TestsResult.getErrorReport();
+        assertThat(errorReport).contains("Expected heap allocation (test method thread) to be less than 439 bytes but is 440 bytes");
+
+    }
+
+}

--- a/junit5/junit5-sql-test/src/test/java/org/quickperf/sql/QuickPerfJUnit5SqlTestTemplateTest.java
+++ b/junit5/junit5-sql-test/src/test/java/org/quickperf/sql/QuickPerfJUnit5SqlTestTemplateTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2020 the original author or authors.
+ */
+
+package org.quickperf.sql;
+
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.quickperf.junit5.JUnit5Tests;
+import org.quickperf.junit5.JUnit5Tests.JUnit5TestsResult;
+import org.quickperf.junit5.QuickPerfTest;
+import org.quickperf.sql.annotation.ExpectSelect;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * This test uses @RepeatedTest to test the Test template support as repeated tests are built-in test templates.
+ */
+public class QuickPerfJUnit5SqlTestTemplateTest {
+
+    @QuickPerfTest
+    public static class SqlSelectJUnit5 extends SqlTestBaseJUnit5 {
+
+        @ExpectSelect(2)
+        @RepeatedTest(2)
+        public void execute_one_select_but_five_select_expected() {
+            EntityManager em = emf.createEntityManager();
+            Query query = em.createQuery("FROM " + Book.class.getCanonicalName());
+            query.getResultList();
+        }
+
+    }
+
+    @Test public void
+    should_fail_if_a_sql_performance_property_is_un_respected() {
+
+        // GIVEN
+        Class<?> testClass = SqlSelectJUnit5.class;
+        JUnit5Tests jUnit5Tests = JUnit5Tests.createInstance(testClass);
+
+        // WHEN
+        JUnit5TestsResult jUnit5TestsResult = jUnit5Tests.run();
+
+        // THEN
+        assertThat(jUnit5TestsResult.getNumberOfFailures()).isEqualTo(2);
+
+        String errorReport = jUnit5TestsResult.getErrorReport();
+        assertThat(errorReport).contains("You may think that <2> select statements were sent to the database")
+                               .contains("But there is in fact <1>...")
+                               .contains("select")
+                               .contains("book0_.id")
+                               .contains("from")
+                               .contains("Book book0_");
+
+    }
+
+}


### PR DESCRIPTION
Support JUnit 5 test template: https://junit.org/junit5/docs/current/user-guide/#writing-tests-test-templates

Tests has been integrated with `@RepeatedTest` that is a build-in test template extension for repeated test.
Parameterized test should also works.

As for dynamic test, the annotation will apply for each test invocation derived from the test template method.