### PR TITLE
replace release profile with maven.deploy.skip #126

### DIFF
--- a/junit4/junit4-12-jvm-test/pom.xml
+++ b/junit4/junit4-12-jvm-test/pom.xml
@@ -28,6 +28,7 @@
         <dependencies.max.jdk.version>1.7</dependencies.max.jdk.version>
         <jar.skipIfEmpty>true</jar.skipIfEmpty>
         <maven.install.skip>true</maven.install.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <dependencies>

--- a/junit4/junit4-12-jvm-test/pom.xml
+++ b/junit4/junit4-12-jvm-test/pom.xml
@@ -28,6 +28,7 @@
         <dependencies.max.jdk.version>1.7</dependencies.max.jdk.version>
         <jar.skipIfEmpty>true</jar.skipIfEmpty>
         <gpg.skip>true</gpg.skip>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         <maven.install.skip>true</maven.install.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>

--- a/junit4/junit4-12-jvm-test/pom.xml
+++ b/junit4/junit4-12-jvm-test/pom.xml
@@ -27,6 +27,7 @@
         <maven.compiler.target>1.7</maven.compiler.target>
         <dependencies.max.jdk.version>1.7</dependencies.max.jdk.version>
         <jar.skipIfEmpty>true</jar.skipIfEmpty>
+        <gpg.skip>true</gpg.skip>
         <maven.install.skip>true</maven.install.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>

--- a/junit4/junit4-13-1-jvm-test/pom.xml
+++ b/junit4/junit4-13-1-jvm-test/pom.xml
@@ -29,6 +29,7 @@
         <dependencies.max.jdk.version>1.7</dependencies.max.jdk.version>
         <jar.skipIfEmpty>true</jar.skipIfEmpty>
         <gpg.skip>true</gpg.skip>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         <maven.install.skip>true</maven.install.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>

--- a/junit4/junit4-13-1-jvm-test/pom.xml
+++ b/junit4/junit4-13-1-jvm-test/pom.xml
@@ -28,6 +28,7 @@
         <maven.compiler.target>1.7</maven.compiler.target>
         <dependencies.max.jdk.version>1.7</dependencies.max.jdk.version>
         <jar.skipIfEmpty>true</jar.skipIfEmpty>
+        <gpg.skip>true</gpg.skip>
         <maven.install.skip>true</maven.install.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>

--- a/junit4/junit4-13-1-jvm-test/pom.xml
+++ b/junit4/junit4-13-1-jvm-test/pom.xml
@@ -29,6 +29,7 @@
         <dependencies.max.jdk.version>1.7</dependencies.max.jdk.version>
         <jar.skipIfEmpty>true</jar.skipIfEmpty>
         <maven.install.skip>true</maven.install.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <dependencies>

--- a/junit4/junit4-13-jvm-test/pom.xml
+++ b/junit4/junit4-13-jvm-test/pom.xml
@@ -29,6 +29,7 @@
         <dependencies.max.jdk.version>1.7</dependencies.max.jdk.version>
         <jar.skipIfEmpty>true</jar.skipIfEmpty>
         <gpg.skip>true</gpg.skip>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         <maven.install.skip>true</maven.install.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>

--- a/junit4/junit4-13-jvm-test/pom.xml
+++ b/junit4/junit4-13-jvm-test/pom.xml
@@ -28,6 +28,7 @@
         <maven.compiler.target>1.7</maven.compiler.target>
         <dependencies.max.jdk.version>1.7</dependencies.max.jdk.version>
         <jar.skipIfEmpty>true</jar.skipIfEmpty>
+        <gpg.skip>true</gpg.skip>
         <maven.install.skip>true</maven.install.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>

--- a/junit4/junit4-13-jvm-test/pom.xml
+++ b/junit4/junit4-13-jvm-test/pom.xml
@@ -29,6 +29,7 @@
         <dependencies.max.jdk.version>1.7</dependencies.max.jdk.version>
         <jar.skipIfEmpty>true</jar.skipIfEmpty>
         <maven.install.skip>true</maven.install.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <dependencies>

--- a/junit4/junit4-5-jvm-test/pom.xml
+++ b/junit4/junit4-5-jvm-test/pom.xml
@@ -28,7 +28,9 @@
         <maven.compiler.target>1.7</maven.compiler.target>
         <dependencies.max.jdk.version>1.7</dependencies.max.jdk.version>
         <jar.skipIfEmpty>true</jar.skipIfEmpty>
+        <gpg.skip>true</gpg.skip>
         <maven.install.skip>true</maven.install.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <dependencies>

--- a/junit4/junit4-5-jvm-test/pom.xml
+++ b/junit4/junit4-5-jvm-test/pom.xml
@@ -29,6 +29,7 @@
         <dependencies.max.jdk.version>1.7</dependencies.max.jdk.version>
         <jar.skipIfEmpty>true</jar.skipIfEmpty>
         <gpg.skip>true</gpg.skip>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         <maven.install.skip>true</maven.install.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>

--- a/junit4/junit4-sql-test/pom.xml
+++ b/junit4/junit4-sql-test/pom.xml
@@ -28,6 +28,7 @@
         <dependencies.max.jdk.version>1.8</dependencies.max.jdk.version>
         <jar.skipIfEmpty>true</jar.skipIfEmpty>
         <gpg.skip>true</gpg.skip>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         <maven.install.skip>true</maven.install.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>

--- a/junit4/junit4-sql-test/pom.xml
+++ b/junit4/junit4-sql-test/pom.xml
@@ -28,6 +28,7 @@
         <dependencies.max.jdk.version>1.8</dependencies.max.jdk.version>
         <jar.skipIfEmpty>true</jar.skipIfEmpty>
         <maven.install.skip>true</maven.install.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <dependencies>

--- a/junit4/junit4-sql-test/pom.xml
+++ b/junit4/junit4-sql-test/pom.xml
@@ -27,6 +27,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <dependencies.max.jdk.version>1.8</dependencies.max.jdk.version>
         <jar.skipIfEmpty>true</jar.skipIfEmpty>
+        <gpg.skip>true</gpg.skip>
         <maven.install.skip>true</maven.install.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>

--- a/junit4/pom.xml
+++ b/junit4/pom.xml
@@ -22,27 +22,13 @@
 
     <packaging>pom</packaging>
 
-    <profiles>
-        <profile>
-            <id>default</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <modules>
-                <module>junit4-runner</module>
-                <module>junit4-5-jvm-test</module>
-                <module>junit4-12-jvm-test</module>
-                <module>junit4-13-jvm-test</module>
-                <module>junit4-13-1-jvm-test</module>
-                <module>junit4-sql-test</module>
-            </modules>
-        </profile>
-        <profile>
-            <id>release</id>
-            <modules>
-                <module>junit4-runner</module>
-            </modules>
-        </profile>
-    </profiles>
+    <modules>
+        <module>junit4-runner</module>
+        <module>junit4-5-jvm-test</module>
+        <module>junit4-12-jvm-test</module>
+        <module>junit4-13-jvm-test</module>
+        <module>junit4-13-1-jvm-test</module>
+        <module>junit4-sql-test</module>
+    </modules>
 
 </project>

--- a/junit5/junit5-jvm-test/pom.xml
+++ b/junit5/junit5-jvm-test/pom.xml
@@ -27,6 +27,7 @@
         <maven.install.skip>true</maven.install.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
         <gpg.skip>true</gpg.skip>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
     </properties>
 
     <dependencies>

--- a/junit5/junit5-jvm-test/pom.xml
+++ b/junit5/junit5-jvm-test/pom.xml
@@ -26,6 +26,7 @@
         <jar.skipIfEmpty>true</jar.skipIfEmpty>
         <maven.install.skip>true</maven.install.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <gpg.skip>true</gpg.skip>
     </properties>
 
     <dependencies>

--- a/junit5/junit5-jvm-test/pom.xml
+++ b/junit5/junit5-jvm-test/pom.xml
@@ -25,6 +25,7 @@
     <properties>
         <jar.skipIfEmpty>true</jar.skipIfEmpty>
         <maven.install.skip>true</maven.install.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <dependencies>

--- a/junit5/junit5-sql-test/pom.xml
+++ b/junit5/junit5-sql-test/pom.xml
@@ -27,6 +27,7 @@
         <maven.install.skip>true</maven.install.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
         <gpg.skip>true</gpg.skip>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
     </properties>
 
     <dependencies>

--- a/junit5/junit5-sql-test/pom.xml
+++ b/junit5/junit5-sql-test/pom.xml
@@ -26,6 +26,7 @@
         <jar.skipIfEmpty>true</jar.skipIfEmpty>
         <maven.install.skip>true</maven.install.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <gpg.skip>true</gpg.skip>
     </properties>
 
     <dependencies>

--- a/junit5/junit5-sql-test/pom.xml
+++ b/junit5/junit5-sql-test/pom.xml
@@ -25,6 +25,7 @@
     <properties>
         <jar.skipIfEmpty>true</jar.skipIfEmpty>
         <maven.install.skip>true</maven.install.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <dependencies>

--- a/junit5/junit5-test-util/pom.xml
+++ b/junit5/junit5-test-util/pom.xml
@@ -24,6 +24,7 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <gpg.skip>true</gpg.skip>
     </properties>
 
     <build>

--- a/junit5/junit5-test-util/pom.xml
+++ b/junit5/junit5-test-util/pom.xml
@@ -25,6 +25,7 @@
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
         <gpg.skip>true</gpg.skip>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
     </properties>
 
     <build>

--- a/junit5/junit5-test-util/pom.xml
+++ b/junit5/junit5-test-util/pom.xml
@@ -22,6 +22,10 @@
 
     <artifactId>quick-perf-junit5-test-util</artifactId>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/junit5/pom.xml
+++ b/junit5/pom.xml
@@ -30,25 +30,11 @@
         <junit5.platform.version>1.6.2</junit5.platform.version>
     </properties>
 
-    <profiles>
-        <profile>
-            <id>default</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <modules>
-                <module>junit5-extension</module>
-                <module>junit5-test-util</module>
-                <module>junit5-jvm-test</module>
-                <module>junit5-sql-test</module>
-            </modules>
-        </profile>
-        <profile>
-            <id>release</id>
-            <modules>
-                <module>junit5-extension</module>
-            </modules>
-        </profile>
-    </profiles>
+    <modules>
+        <module>junit5-extension</module>
+        <module>junit5-test-util</module>
+        <module>junit5-jvm-test</module>
+        <module>junit5-sql-test</module>
+    </modules>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -158,35 +158,20 @@
         <url>https://github.com/quick-perf/quickperf/issues</url>
     </issueManagement>
 
+    <modules>
+        <module>core</module>
+        <module>jvm</module>
+        <module>sql</module>
+        <module>junit4</module>
+        <module>junit5</module>
+        <module>testng</module>
+        <module>spring</module>
+        <module>bom</module>
+    </modules>
+
     <profiles>
         <profile>
-            <id>default</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <modules>
-                <module>core</module>
-                <module>jvm</module>
-                <module>sql</module>
-                <module>junit4</module>
-                <module>junit5</module>
-                <module>testng</module>
-                <module>spring</module>
-                <module>bom</module>
-            </modules>
-        </profile>
-        <profile>
             <id>release</id>
-            <modules>
-                <module>core</module>
-                <module>jvm</module>
-                <module>sql</module>
-                <module>junit4</module>
-                <module>junit5</module>
-                <module>testng</module>
-                <module>spring</module>
-                <module>bom</module>
-            </modules>
             <build>
                 <plugins>
                     <plugin>

--- a/spring/junit4-spring-base-tests/pom.xml
+++ b/spring/junit4-spring-base-tests/pom.xml
@@ -26,6 +26,7 @@
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <gpg.skip>true</gpg.skip>
     </properties>
 
     <dependencies>

--- a/spring/junit4-spring-base-tests/pom.xml
+++ b/spring/junit4-spring-base-tests/pom.xml
@@ -27,6 +27,7 @@
         <maven.compiler.target>1.7</maven.compiler.target>
         <maven.deploy.skip>true</maven.deploy.skip>
         <gpg.skip>true</gpg.skip>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
     </properties>
 
     <dependencies>

--- a/spring/junit4-spring-base-tests/pom.xml
+++ b/spring/junit4-spring-base-tests/pom.xml
@@ -25,6 +25,7 @@
     <properties>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <dependencies>

--- a/spring/junit4-spring-boot-test/pom.xml
+++ b/spring/junit4-spring-boot-test/pom.xml
@@ -32,6 +32,9 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <dependencies.max.jdk.version>1.8</dependencies.max.jdk.version>
         <maven.install.skip>true</maven.install.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <gpg.skip>true</gpg.skip>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
     </properties>
 
     <dependencies>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -28,23 +28,18 @@
         <spring5-version>5.1.8.RELEASE</spring5-version>
     </properties>
 
+    <modules>
+        <module>sql-spring4</module>
+        <module>sql-spring5</module>
+        <module>junit4-spring3</module>
+        <module>junit4-spring4</module>
+        <module>junit4-spring5</module>
+        <module>spring-boot-1-starter</module>
+        <module>spring-boot-2-starter</module>
+        <module>junit4-spring-base-tests</module>
+    </modules>
+
     <profiles>
-        <profile>
-            <id>default</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <modules>
-                <module>sql-spring4</module>
-                <module>sql-spring5</module>
-                <module>junit4-spring3</module>
-                <module>junit4-spring4</module>
-                <module>junit4-spring5</module>
-                <module>spring-boot-1-starter</module>
-                <module>spring-boot-2-starter</module>
-                <module>junit4-spring-base-tests</module>
-            </modules>
-        </profile>
         <profile>
             <id>SpringBootTests</id>
             <activation>
@@ -52,18 +47,6 @@
             </activation>
             <modules>
                 <module>junit4-spring-boot-test</module>
-            </modules>
-        </profile>
-        <profile>
-            <id>release</id>
-            <modules>
-                <module>sql-spring4</module>
-                <module>sql-spring5</module>
-                <module>junit4-spring3</module>
-                <module>junit4-spring4</module>
-                <module>junit4-spring5</module>
-                <module>spring-boot-1-starter</module>
-                <module>spring-boot-2-starter</module>
             </modules>
         </profile>
     </profiles>

--- a/sql/pom.xml
+++ b/sql/pom.xml
@@ -24,25 +24,14 @@
 
     <packaging>pom</packaging>
 
+    <modules>
+        <module>sql-annotations</module>
+        <module>sql-memory-test-util</module>
+        <module>sql-hibernate-test-util</module>
+        <module>sql-memory-test</module>
+    </modules>
+
     <profiles>
-        <profile>
-            <id>default</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <modules>
-                <module>sql-annotations</module>
-                <module>sql-memory-test-util</module>
-                <module>sql-hibernate-test-util</module>
-                <module>sql-memory-test</module>
-            </modules>
-        </profile>
-        <profile>
-            <id>release</id>
-            <modules>
-                <module>sql-annotations</module>
-            </modules>
-        </profile>
         <profile>
             <id>testcontainers</id>
             <modules>

--- a/sql/sql-hibernate-test-util/pom.xml
+++ b/sql/sql-hibernate-test-util/pom.xml
@@ -27,6 +27,7 @@
         <dependencies.max.jdk.version>1.8</dependencies.max.jdk.version>
         <maven.deploy.skip>true</maven.deploy.skip>
         <gpg.skip>true</gpg.skip>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
     </properties>
 
     <dependencies>

--- a/sql/sql-hibernate-test-util/pom.xml
+++ b/sql/sql-hibernate-test-util/pom.xml
@@ -25,6 +25,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <dependencies.max.jdk.version>1.8</dependencies.max.jdk.version>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <dependencies>

--- a/sql/sql-hibernate-test-util/pom.xml
+++ b/sql/sql-hibernate-test-util/pom.xml
@@ -26,6 +26,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <dependencies.max.jdk.version>1.8</dependencies.max.jdk.version>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <gpg.skip>true</gpg.skip>
     </properties>
 
     <dependencies>

--- a/sql/sql-memory-test-util/pom.xml
+++ b/sql/sql-memory-test-util/pom.xml
@@ -27,6 +27,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <dependencies.max.jdk.version>1.8</dependencies.max.jdk.version>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <gpg.skip>true</gpg.skip>
     </properties>
 
     <dependencies>

--- a/sql/sql-memory-test-util/pom.xml
+++ b/sql/sql-memory-test-util/pom.xml
@@ -26,6 +26,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <dependencies.max.jdk.version>1.8</dependencies.max.jdk.version>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <dependencies>

--- a/sql/sql-memory-test-util/pom.xml
+++ b/sql/sql-memory-test-util/pom.xml
@@ -28,6 +28,7 @@
         <dependencies.max.jdk.version>1.8</dependencies.max.jdk.version>
         <maven.deploy.skip>true</maven.deploy.skip>
         <gpg.skip>true</gpg.skip>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
     </properties>
 
     <dependencies>

--- a/sql/sql-memory-test/pom.xml
+++ b/sql/sql-memory-test/pom.xml
@@ -28,6 +28,7 @@
         <dependencies.max.jdk.version>1.8</dependencies.max.jdk.version>
         <jar.skipIfEmpty>true</jar.skipIfEmpty>
         <gpg.skip>true</gpg.skip>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         <maven.install.skip>true</maven.install.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>

--- a/sql/sql-memory-test/pom.xml
+++ b/sql/sql-memory-test/pom.xml
@@ -28,6 +28,7 @@
         <dependencies.max.jdk.version>1.8</dependencies.max.jdk.version>
         <jar.skipIfEmpty>true</jar.skipIfEmpty>
         <maven.install.skip>true</maven.install.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <dependencies>

--- a/sql/sql-memory-test/pom.xml
+++ b/sql/sql-memory-test/pom.xml
@@ -27,6 +27,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <dependencies.max.jdk.version>1.8</dependencies.max.jdk.version>
         <jar.skipIfEmpty>true</jar.skipIfEmpty>
+        <gpg.skip>true</gpg.skip>
         <maven.install.skip>true</maven.install.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>

--- a/testng/pom.xml
+++ b/testng/pom.xml
@@ -29,26 +29,12 @@
         <dependencies.max.jdk.version>8</dependencies.max.jdk.version>
     </properties>
 
-    <profiles>
-        <profile>
-            <id>default</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <modules>
-                <module>testng-listener</module>
-                <module>testng-test-util</module>
-                <module>testng-sql-test</module>
-                <module>testng-jvm-test</module>
-            </modules>
-        </profile>
-        <profile>
-            <id>release</id>
-            <modules>
-                <module>testng-listener</module>
-            </modules>
-        </profile>
-    </profiles>
+    <modules>
+        <module>testng-listener</module>
+        <module>testng-test-util</module>
+        <module>testng-sql-test</module>
+        <module>testng-jvm-test</module>
+    </modules>
 
     <build>
         <plugins>

--- a/testng/testng-jvm-test/pom.xml
+++ b/testng/testng-jvm-test/pom.xml
@@ -23,6 +23,7 @@
 
     <properties>
         <jar.skipIfEmpty>true</jar.skipIfEmpty>
+        <gpg.skip>true</gpg.skip>
         <maven.install.skip>true</maven.install.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>

--- a/testng/testng-jvm-test/pom.xml
+++ b/testng/testng-jvm-test/pom.xml
@@ -24,6 +24,7 @@
     <properties>
         <jar.skipIfEmpty>true</jar.skipIfEmpty>
         <maven.install.skip>true</maven.install.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <dependencies>

--- a/testng/testng-jvm-test/pom.xml
+++ b/testng/testng-jvm-test/pom.xml
@@ -24,6 +24,7 @@
     <properties>
         <jar.skipIfEmpty>true</jar.skipIfEmpty>
         <gpg.skip>true</gpg.skip>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         <maven.install.skip>true</maven.install.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>

--- a/testng/testng-sql-test/pom.xml
+++ b/testng/testng-sql-test/pom.xml
@@ -27,6 +27,7 @@
     <properties>
         <jar.skipIfEmpty>true</jar.skipIfEmpty>
         <gpg.skip>true</gpg.skip>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         <maven.install.skip>true</maven.install.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>

--- a/testng/testng-sql-test/pom.xml
+++ b/testng/testng-sql-test/pom.xml
@@ -27,6 +27,7 @@
     <properties>
         <jar.skipIfEmpty>true</jar.skipIfEmpty>
         <maven.install.skip>true</maven.install.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <dependencies>

--- a/testng/testng-sql-test/pom.xml
+++ b/testng/testng-sql-test/pom.xml
@@ -26,6 +26,7 @@
 
     <properties>
         <jar.skipIfEmpty>true</jar.skipIfEmpty>
+        <gpg.skip>true</gpg.skip>
         <maven.install.skip>true</maven.install.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>

--- a/testng/testng-test-util/pom.xml
+++ b/testng/testng-test-util/pom.xml
@@ -26,6 +26,7 @@
 
     <properties>
         <gpg.skip>true</gpg.skip>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 

--- a/testng/testng-test-util/pom.xml
+++ b/testng/testng-test-util/pom.xml
@@ -25,6 +25,7 @@
     <artifactId>quick-perf-testng-test-util</artifactId>
 
     <properties>
+        <gpg.skip>true</gpg.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 

--- a/testng/testng-test-util/pom.xml
+++ b/testng/testng-test-util/pom.xml
@@ -22,6 +22,12 @@
 
     <modelVersion>4.0.0</modelVersion>
 
+    <artifactId>quick-perf-testng-test-util</artifactId>
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.testng</groupId>
@@ -30,8 +36,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <artifactId>quick-perf-testng-test-util</artifactId>
 
     <build>
         <plugins>


### PR DESCRIPTION
this will avoid build failures of release because pom version has not been updated and is still at 1.0-SNAPSHOT, while still avoiding deploying artifacts