### PR TITLE
QuickPerfSpringRunner did not call the Spring TestExecutionListener instances before the test method execution

### DIFF
--- a/spring/junit4-spring-boot-test/src/main/java/org/quickperf/spring/springboottest/jpa/entity/Player.java
+++ b/spring/junit4-spring-boot-test/src/main/java/org/quickperf/spring/springboottest/jpa/entity/Player.java
@@ -18,7 +18,7 @@ import java.io.Serializable;
 public class Player implements Serializable {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String firstName;

--- a/spring/junit4-spring-boot-test/src/test/java/org/quickperf/spring/springboottest/QuickPerfSpringRunnerBeforeNewJvmTest.java
+++ b/spring/junit4-spring-boot-test/src/test/java/org/quickperf/spring/springboottest/QuickPerfSpringRunnerBeforeNewJvmTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2020 the original author or authors.
+ */
+
+package org.quickperf.spring.springboottest;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.quickperf.annotation.DisableGlobalAnnotations;
+import org.quickperf.jvm.allocation.AllocationUnit;
+import org.quickperf.jvm.annotations.HeapSize;
+import org.quickperf.spring.junit4.QuickPerfSpringRunner;
+import org.quickperf.spring.springboottest.jpa.entity.Player;
+import org.quickperf.spring.springboottest.jpa.repository.PlayerRepository;
+import org.quickperf.spring.sql.QuickPerfSqlConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(QuickPerfSpringRunner.class)
+@Import(QuickPerfSqlConfig.class)
+@DataJpaTest()
+@DisableGlobalAnnotations
+public class QuickPerfSpringRunnerBeforeNewJvmTest {
+
+    @Autowired
+    private TestEntityManager testEntityManager;
+
+    @Autowired
+    private PlayerRepository playerRepository;
+
+    @Before
+    public void before() {
+        Player player = new Player();
+        testEntityManager.persist(player);
+    }
+
+    @HeapSize(value = 50, unit = AllocationUnit.MEGA_BYTE)
+    @Test
+    public void should_find_all_players() {
+        List<Player> players = playerRepository.findAll();
+        assertThat(players).hasSize(3);
+    }
+
+}

--- a/spring/junit4-spring-boot-test/src/test/java/org/quickperf/spring/springboottest/QuickPerfSpringRunnerBeforeTest.java
+++ b/spring/junit4-spring-boot-test/src/test/java/org/quickperf/spring/springboottest/QuickPerfSpringRunnerBeforeTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2020 the original author or authors.
+ */
+
+package org.quickperf.spring.springboottest;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.quickperf.annotation.DisableGlobalAnnotations;
+import org.quickperf.spring.junit4.QuickPerfSpringRunner;
+import org.quickperf.spring.springboottest.jpa.entity.Player;
+import org.quickperf.spring.springboottest.jpa.repository.PlayerRepository;
+import org.quickperf.spring.sql.QuickPerfSqlConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(QuickPerfSpringRunner.class)
+@Import(QuickPerfSqlConfig.class)
+@DataJpaTest()
+@DisableGlobalAnnotations
+public class QuickPerfSpringRunnerBeforeTest {
+
+    @Autowired
+    private TestEntityManager testEntityManager;
+
+    @Autowired
+    private PlayerRepository playerRepository;
+
+    @Before
+    public void before() {
+        Player player = new Player();
+        testEntityManager.persist(player);
+    }
+
+    @Test
+    public void should_find_all_players() {
+        List<Player> players = playerRepository.findAll();
+        assertThat(players).hasSize(3);
+    }
+
+}

--- a/spring/junit4-spring3/src/main/java/org/quickperf/spring/junit4/SpringRunnerWithQuickPerfFeatures.java
+++ b/spring/junit4-spring3/src/main/java/org/quickperf/spring/junit4/SpringRunnerWithQuickPerfFeatures.java
@@ -56,8 +56,7 @@ class SpringRunnerWithQuickPerfFeatures extends SpringJUnit4ClassRunner {
 
     @Override
     public Statement withBefores(FrameworkMethod frameworkMethod, Object testInstance, Statement statement) {
-        Statement springBefores = super.withBefores(frameworkMethod, testInstance, statement);
-        return quickPerfJUnitRunner.withBefores(frameworkMethod, testInstance, springBefores);
+        return super.withBefores(frameworkMethod, testInstance, statement);
     }
 
     @Override

--- a/spring/junit4-spring4/src/main/java/org/quickperf/spring/junit4/SpringRunnerWithQuickPerfFeatures.java
+++ b/spring/junit4-spring4/src/main/java/org/quickperf/spring/junit4/SpringRunnerWithQuickPerfFeatures.java
@@ -56,8 +56,7 @@ class SpringRunnerWithQuickPerfFeatures extends SpringJUnit4ClassRunner {
 
     @Override
     public Statement withBefores(FrameworkMethod frameworkMethod, Object testInstance, Statement statement) {
-        Statement springBefores = super.withBefores(frameworkMethod, testInstance, statement);
-        return quickPerfJUnitRunner.withBefores(frameworkMethod, testInstance, springBefores);
+        return super.withBefores(frameworkMethod, testInstance, statement);
     }
 
     @Override

--- a/spring/junit4-spring5/src/main/java/org/quickperf/spring/junit4/SpringRunnerWithQuickPerfFeatures.java
+++ b/spring/junit4-spring5/src/main/java/org/quickperf/spring/junit4/SpringRunnerWithQuickPerfFeatures.java
@@ -56,8 +56,7 @@ class SpringRunnerWithQuickPerfFeatures extends SpringJUnit4ClassRunner {
 
     @Override
     public Statement withBefores(FrameworkMethod frameworkMethod, Object testInstance, Statement statement) {
-        Statement springBefores = super.withBefores(frameworkMethod, testInstance, statement);
-        return quickPerfJUnitRunner.withBefores(frameworkMethod, testInstance, springBefores);
+       return super.withBefores(frameworkMethod, testInstance, statement);
     }
 
     @Override


### PR DESCRIPTION
### Bug example

```java

@RunWith(QuickPerfSpringRunner.class)
@Import(QuickPerfSqlConfig.class)
@DataJpaTest()
public class QuickPerfSpringRunnerBeforeTest {

    @Autowired
    private TestEntityManager testEntityManager;

    @Before
    public void before() {
        Player player = new Player();
        testEntityManager.persist(player);
    }

    @Test
    public void test() {
    }

}



```

Exception: `java.lang.IllegalStateException: No transactional EntityManager found`