### PR TITLE
QuickPerfSpringRunner did not call the Spring TestExecutionListener instances after the test method execution

### DIFF
--- a/spring/junit4-spring-boot-test/src/test/java/org/quickperf/spring/springboottest/QuickPerfSpringRunnerBeforeAfterNewJvmTest.java
+++ b/spring/junit4-spring-boot-test/src/test/java/org/quickperf/spring/springboottest/QuickPerfSpringRunnerBeforeAfterNewJvmTest.java
@@ -11,10 +11,13 @@
 
 package org.quickperf.spring.springboottest;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.quickperf.annotation.DisableGlobalAnnotations;
+import org.quickperf.jvm.allocation.AllocationUnit;
+import org.quickperf.jvm.annotations.HeapSize;
 import org.quickperf.spring.junit4.QuickPerfSpringRunner;
 import org.quickperf.spring.springboottest.jpa.entity.Player;
 import org.quickperf.spring.springboottest.jpa.repository.PlayerRepository;
@@ -32,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Import(QuickPerfSqlConfig.class)
 @DataJpaTest()
 @DisableGlobalAnnotations
-public class QuickPerfSpringRunnerBeforeTest {
+public class QuickPerfSpringRunnerBeforeAfterNewJvmTest {
 
     @Autowired
     private TestEntityManager testEntityManager;
@@ -46,10 +49,17 @@ public class QuickPerfSpringRunnerBeforeTest {
         testEntityManager.persist(player);
     }
 
+    @HeapSize(value = 50, unit = AllocationUnit.MEGA_BYTE)
     @Test
     public void should_find_all_players() {
         List<Player> players = playerRepository.findAll();
         assertThat(players).hasSize(3);
+    }
+
+    @After
+    public void after() {
+        Player player = new Player();
+        testEntityManager.persist(player);
     }
 
 }

--- a/spring/junit4-spring-boot-test/src/test/java/org/quickperf/spring/springboottest/QuickPerfSpringRunnerBeforeAfterTest.java
+++ b/spring/junit4-spring-boot-test/src/test/java/org/quickperf/spring/springboottest/QuickPerfSpringRunnerBeforeAfterTest.java
@@ -11,12 +11,11 @@
 
 package org.quickperf.spring.springboottest;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.quickperf.annotation.DisableGlobalAnnotations;
-import org.quickperf.jvm.allocation.AllocationUnit;
-import org.quickperf.jvm.annotations.HeapSize;
 import org.quickperf.spring.junit4.QuickPerfSpringRunner;
 import org.quickperf.spring.springboottest.jpa.entity.Player;
 import org.quickperf.spring.springboottest.jpa.repository.PlayerRepository;
@@ -34,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Import(QuickPerfSqlConfig.class)
 @DataJpaTest()
 @DisableGlobalAnnotations
-public class QuickPerfSpringRunnerBeforeNewJvmTest {
+public class QuickPerfSpringRunnerBeforeAfterTest {
 
     @Autowired
     private TestEntityManager testEntityManager;
@@ -48,11 +47,16 @@ public class QuickPerfSpringRunnerBeforeNewJvmTest {
         testEntityManager.persist(player);
     }
 
-    @HeapSize(value = 50, unit = AllocationUnit.MEGA_BYTE)
     @Test
     public void should_find_all_players() {
         List<Player> players = playerRepository.findAll();
         assertThat(players).hasSize(3);
+    }
+
+    @After
+    public void after() {
+        Player player = new Player();
+        testEntityManager.persist(player);
     }
 
 }

--- a/spring/junit4-spring3/src/main/java/org/quickperf/spring/junit4/SpringRunnerWithQuickPerfFeatures.java
+++ b/spring/junit4-spring3/src/main/java/org/quickperf/spring/junit4/SpringRunnerWithQuickPerfFeatures.java
@@ -61,8 +61,8 @@ class SpringRunnerWithQuickPerfFeatures extends SpringJUnit4ClassRunner {
 
     @Override
     public Statement withAfters(FrameworkMethod frameworkMethod, Object testInstance, Statement statement) {
-        Statement springAfters = super.withAfters(frameworkMethod, testInstance, statement);
-        return quickPerfJUnitRunner.withAfters(frameworkMethod, testInstance, springAfters);
+        Statement quickPerfStatement = quickPerfJUnitRunner.withAfters(frameworkMethod, testInstance, statement);
+        return super.withAfters(frameworkMethod, testInstance, quickPerfStatement);
     }
 
     @Override

--- a/spring/junit4-spring4/src/main/java/org/quickperf/spring/junit4/SpringRunnerWithQuickPerfFeatures.java
+++ b/spring/junit4-spring4/src/main/java/org/quickperf/spring/junit4/SpringRunnerWithQuickPerfFeatures.java
@@ -61,8 +61,8 @@ class SpringRunnerWithQuickPerfFeatures extends SpringJUnit4ClassRunner {
 
     @Override
     public Statement withAfters(FrameworkMethod frameworkMethod, Object testInstance, Statement statement) {
-        Statement springAfters = super.withAfters(frameworkMethod, testInstance, statement);
-        return quickPerfJUnitRunner.withAfters(frameworkMethod, testInstance, springAfters);
+        Statement quickPerfStatement = quickPerfJUnitRunner.withAfters(frameworkMethod, testInstance, statement);
+        return super.withAfters(frameworkMethod, testInstance, quickPerfStatement);
     }
 
     @Override

--- a/spring/junit4-spring5/src/main/java/org/quickperf/spring/junit4/SpringRunnerWithQuickPerfFeatures.java
+++ b/spring/junit4-spring5/src/main/java/org/quickperf/spring/junit4/SpringRunnerWithQuickPerfFeatures.java
@@ -61,8 +61,8 @@ class SpringRunnerWithQuickPerfFeatures extends SpringJUnit4ClassRunner {
 
     @Override
     public Statement withAfters(FrameworkMethod frameworkMethod, Object testInstance, Statement statement) {
-        Statement springAfters = super.withAfters(frameworkMethod, testInstance, statement);
-        return quickPerfJUnitRunner.withAfters(frameworkMethod, testInstance, springAfters);
+        Statement quickPerfStatement = quickPerfJUnitRunner.withAfters(frameworkMethod, testInstance, statement);
+        return super.withAfters(frameworkMethod, testInstance, quickPerfStatement);
     }
 
     @Override


### PR DESCRIPTION
### Bug example

```java
@RunWith(QuickPerfSpringRunner.class)
@Import(QuickPerfSqlConfig.class)
@DataJpaTest()
public class QuickPerfSpringRunnerAfterTest {

    @Autowired
    private TestEntityManager testEntityManager;

    @Test
    public void should_find_all_players() {
    }

    @After
    public void after() {
        Player player = new Player();
        testEntityManager.persist(player);
    }
    
}
```

Exception:  `No transactional EntityManager found`