### PR TITLE
Could org.quickperf:quick-perf-sql-hibernate-test-util:1.0.2-SNAPSHOT drop off redundant dependencies to loose weight?

### DIFF
--- a/sql/sql-hibernate-test-util/pom.xml
+++ b/sql/sql-hibernate-test-util/pom.xml
@@ -33,6 +33,40 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-entitymanager</artifactId>
             <version>5.4.0.Final</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hibernate</groupId>
+                    <artifactId>hibernate-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.hibernate.common</groupId>
+                    <artifactId>hibernate-commons-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.dom4j</groupId>
+                    <artifactId>dom4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>byte-buddy</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.transaction</groupId>
+                    <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>javax.activation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
@jeanbisutti Hi, I am a user of project **_org.quickperf:quick-perf-sql-hibernate-test-util:1.0.2-SNAPSHOT_**. I found that its pom file introduced **_21_** dependencies. However, among them, **_17_** libraries (**_80%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for users of your package. 
This PR helps **_org.quickperf:quick-perf-sql-hibernate-test-util:1.0.2-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
org.jboss:jandex:jar:2.0.5.Final:compile
org.glassfish.jaxb:jaxb-runtime:jar:2.3.1:compile
org.hibernate.common:hibernate-commons-annotations:jar:5.1.0.Final:compile
org.hibernate:hibernate-core:jar:5.4.0.Final:compile
com.sun.istack:istack-commons-runtime:jar:3.0.7:compile
org.jboss.logging:jboss-logging:jar:3.3.2.Final:compile
javax.xml.bind:jaxb-api:jar:2.3.1:compile
org.glassfish.jaxb:txw2:jar:2.3.1:compile
com.sun.xml.fastinfoset:FastInfoset:jar:1.2.15:compile
javax.activation:javax.activation-api:jar:1.2.0:compile
org.jboss.spec.javax.transaction:jboss-transaction-api_1.2_spec:jar:1.1.1.Final:compile
org.jvnet.staxex:stax-ex:jar:1.8:compile
antlr:antlr:jar:2.7.7:compile
org.javassist:javassist:jar:3.24.0-GA:compile
net.bytebuddy:byte-buddy:jar:1.9.5:compile
com.fasterxml:classmate:jar:1.3.4:compile
org.dom4j:dom4j:jar:2.1.1:compile
</code></pre>