### PR TITLE
Add TestNG SQL Listener

### DIFF
--- a/testng/pom.xml
+++ b/testng/pom.xml
@@ -34,6 +34,7 @@
         <module>testng-test-util</module>
         <module>testng-sql-test</module>
         <module>testng-jvm-test</module>
+        <module>testng-sql-listener</module>
     </modules>
 
     <build>

--- a/testng/testng-sql-listener/pom.xml
+++ b/testng/testng-sql-listener/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+  ~ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+  ~
+  ~ Copyright 2019-2021 the original author or authors.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quick-perf-testng-parent</artifactId>
+        <groupId>org.quickperf</groupId>
+        <version>1.1.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quick-perf-testng-sql-listener</artifactId>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <dependencies.max.jdk.version>1.8</dependencies.max.jdk.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>7.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.quickperf</groupId>
+            <artifactId>quick-perf-core</artifactId>
+            <version>1.1.1-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/testng/testng-sql-listener/src/main/java/org/quickperf/testng/QuickPerfSqlTestNGListener.java
+++ b/testng/testng-sql-listener/src/main/java/org/quickperf/testng/QuickPerfSqlTestNGListener.java
@@ -1,0 +1,79 @@
+package org.quickperf.testng;
+
+import org.quickperf.TestExecutionContext;
+import org.quickperf.config.library.QuickPerfConfigs;
+import org.quickperf.config.library.QuickPerfConfigsLoader;
+import org.quickperf.config.library.SetOfAnnotationConfigs;
+import org.quickperf.issue.JvmOrTestIssue;
+import org.quickperf.issue.PerfIssuesEvaluator;
+import org.quickperf.issue.PerfIssuesToFormat;
+import org.quickperf.perfrecording.PerformanceRecording;
+import org.quickperf.reporter.QuickPerfReporter;
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
+import org.testng.ITestNGMethod;
+import org.testng.ITestResult;
+
+import java.lang.reflect.Method;
+import java.util.Collection;
+
+public class QuickPerfSqlTestNGListener implements IInvokedMethodListener {
+
+    private final QuickPerfConfigs quickPerfConfigs = QuickPerfConfigsLoader.INSTANCE.loadQuickPerfConfigs();
+
+    private final PerfIssuesEvaluator perfIssuesEvaluator = PerfIssuesEvaluator.INSTANCE;
+
+    private final PerformanceRecording performanceRecording = PerformanceRecording.INSTANCE;
+
+    private final QuickPerfReporter quickPerfReporter = QuickPerfReporter.INSTANCE;
+
+    private TestExecutionContext testExecutionContext;
+
+    @Override
+    public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
+        TestExecutionContext testExecutionContext = buildTestExecutionContextFrom(method);
+        this.testExecutionContext = testExecutionContext;
+
+        if (!this.testExecutionContext.isQuickPerfDisabled()) {
+            performanceRecording.start(this.testExecutionContext);
+        }
+    }
+
+    private TestExecutionContext buildTestExecutionContextFrom(IInvokedMethod method) {
+        ITestNGMethod testNGMethod = method.getTestMethod();
+        Method testMethod = testNGMethod.getConstructorOrMethod().getMethod();
+        int noAllocationOffsetBecauseOnlyOneJvm = 0;
+        return TestExecutionContext.buildFrom(quickPerfConfigs, testMethod, noAllocationOffsetBecauseOnlyOneJvm);
+    }
+
+    @Override
+    public void afterInvocation(IInvokedMethod method, ITestResult testResult) {
+
+        if(!testExecutionContext.isQuickPerfDisabled()) {
+            performanceRecording.stop(testExecutionContext);
+        }
+
+        SetOfAnnotationConfigs testAnnotationConfigs = quickPerfConfigs.getTestAnnotationConfigs();
+
+        // Test issue should be taken into account
+        JvmOrTestIssue jvmOrTestIssue = JvmOrTestIssue.NONE;
+
+        Collection<PerfIssuesToFormat> groupOfPerfIssuesToFormat =
+                perfIssuesEvaluator.evaluatePerfIssuesIfNoJvmIssue( testAnnotationConfigs
+                        , testExecutionContext
+                        , jvmOrTestIssue);
+
+        testExecutionContext.cleanResources();
+
+        try {
+            quickPerfReporter.report(jvmOrTestIssue, groupOfPerfIssuesToFormat, testExecutionContext);
+        } catch (Throwable throwable) {
+            testResult.setThrowable(throwable);
+            testResult.setStatus(ITestResult.FAILURE);
+        }
+
+    }
+
+}
+
+

--- a/testng/testng-sql-listener/src/test/java/org/quickperf/testng/sql/QuickPerfSqlTestNGListenerTest.java
+++ b/testng/testng-sql-listener/src/test/java/org/quickperf/testng/sql/QuickPerfSqlTestNGListenerTest.java
@@ -1,0 +1,28 @@
+package org.quickperf.testng.sql;
+
+import org.quickperf.testng.TestNGTests;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class QuickPerfSqlTestNGListenerTest {
+
+    @Test
+    public void a_test_with_failing_business_code_should_fail() {
+
+        // GIVEN
+        Class<?> testClass = TestNGMethodFailing.class;
+        TestNGTests testNGTests = TestNGTests.createInstance(testClass);
+
+        // WHEN
+        TestNGTests.TestNGTestsResult testsResult = testNGTests.run();
+
+        // THEN
+        assertThat(testsResult.getNumberOfFailedTest()).isOne();
+
+        Throwable errorReport = testsResult.getThrowableOfFirstTest();
+        assertThat(errorReport).hasMessageContaining("expected [false] but found [true]");
+
+    }
+
+}

--- a/testng/testng-sql-listener/src/test/java/org/quickperf/testng/sql/TestNGMethodFailing.java
+++ b/testng/testng-sql-listener/src/test/java/org/quickperf/testng/sql/TestNGMethodFailing.java
@@ -1,0 +1,13 @@
+package org.quickperf.testng.sql;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestNGMethodFailing {
+
+    @Test
+    public void a_failing_test() {
+        Assert.assertEquals(true, false);
+    }
+
+}


### PR DESCRIPTION
#44 TestNG & Spring 

Add QuickPerf SQL TestNG Listener.
Listener can be added as described [here](https://testng.org/doc/documentation-main.html#testng-listeners)
Example usage shown [here](https://github.com/jeanbisutti/quick-perf-testng-spring).
