### PR TITLE
Fix NPE in QuickPerfSpringRunner (JUnit 4) with Surefire

### DIFF
--- a/spring/junit4-spring3/src/main/java/org/quickperf/spring/junit4/QuickPerfSpringRunner.java
+++ b/spring/junit4-spring3/src/main/java/org/quickperf/spring/junit4/QuickPerfSpringRunner.java
@@ -552,6 +552,8 @@ public class QuickPerfSpringRunner extends BlockJUnit4ClassRunner {
             QUICK_PERF_SPRING_RUNNER_FOR_SPECIFIC_JVM.setScheduler(scheduler);
         }  else if (quickPerfFeaturesAreDisabled) {
             springRunner.setScheduler(scheduler);
+        }  else if(springRunnerWithQuickPerfFeatures == null) {
+            super.setScheduler(scheduler);
         } else {
             springRunnerWithQuickPerfFeatures.setScheduler(scheduler);
         }

--- a/spring/junit4-spring4/src/main/java/org/quickperf/spring/junit4/QuickPerfSpringRunner.java
+++ b/spring/junit4-spring4/src/main/java/org/quickperf/spring/junit4/QuickPerfSpringRunner.java
@@ -552,6 +552,8 @@ public class QuickPerfSpringRunner extends BlockJUnit4ClassRunner {
             QUICK_PERF_SPRING_RUNNER_FOR_SPECIFIC_JVM.setScheduler(scheduler);
         }  else if (quickPerfFeaturesAreDisabled) {
             springRunner.setScheduler(scheduler);
+        }  else if(springRunnerWithQuickPerfFeatures == null) {
+            super.setScheduler(scheduler);
         } else {
             springRunnerWithQuickPerfFeatures.setScheduler(scheduler);
         }

--- a/spring/junit4-spring5/src/main/java/org/quickperf/spring/junit4/QuickPerfSpringRunner.java
+++ b/spring/junit4-spring5/src/main/java/org/quickperf/spring/junit4/QuickPerfSpringRunner.java
@@ -552,8 +552,10 @@ public class QuickPerfSpringRunner extends BlockJUnit4ClassRunner {
     public void setScheduler(RunnerScheduler scheduler) {
         if (SystemProperties.TEST_CODE_EXECUTING_IN_NEW_JVM.evaluate()) {
             QUICK_PERF_SPRING_RUNNER_FOR_SPECIFIC_JVM.setScheduler(scheduler);
-        }  else if (quickPerfFeaturesAreDisabled) {
+        } else if (quickPerfFeaturesAreDisabled) {
             springRunner.setScheduler(scheduler);
+        } else if (springRunnerWithQuickPerfFeatures == null) {
+            super.setScheduler(scheduler);
         } else {
             springRunnerWithQuickPerfFeatures.setScheduler(scheduler);
         }


### PR DESCRIPTION
This issue happened during the development of the folowing PR on the update of file headers (license).

The stack:
```
java.lang.NullPointerException
	at org.quickperf.spring.junit4.QuickPerfSpringRunner.setScheduler(QuickPerfSpringRunner.java:558)
	at org.apache.maven.surefire.junitcore.pc.ParallelComputerBuilder$PC.setSchedulers(ParallelComputerBuilder.java:608)
	at org.apache.maven.surefire.junitcore.pc.ParallelComputerBuilder$PC.setSchedulers(ParallelComputerBuilder.java:568)
	at org.apache.maven.surefire.junitcore.pc.ParallelComputerBuilder$PC.getSuite(ParallelComputerBuilder.java:367)
	at org.junit.runner.Request.classes(Request.java:75)
	at org.apache.maven.surefire.junitcore.JUnitCoreWrapper.createRequestAndRun(JUnitCoreWrapper.java:126)
	at org.apache.maven.surefire.junitcore.JUnitCoreWrapper.executeEager(JUnitCoreWrapper.java:107)
	at org.apache.maven.surefire.junitcore.JUnitCoreWrapper.execute(JUnitCoreWrapper.java:83)
	at org.apache.maven.surefire.junitcore.JUnitCoreWrapper.execute(JUnitCoreWrapper.java:75)
	at org.apache.maven.surefire.junitcore.JUnitCoreProvider.invoke(JUnitCoreProvider.java:158)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
```

