### PR TITLE
feat: Making expected SQL annotations more descriptive and repeatable

### DIFF
--- a/junit4/junit4-sql-test/src/test/java/org/quickperf/sql/DisableQuickPerfFeaturesJUnit4Test.java
+++ b/junit4/junit4-sql-test/src/test/java/org/quickperf/sql/DisableQuickPerfFeaturesJUnit4Test.java
@@ -19,6 +19,7 @@ import org.quickperf.annotation.DisableQuickPerf;
 import org.quickperf.annotation.FunctionalIteration;
 import org.quickperf.junit4.QuickPerfJUnitRunner;
 import org.quickperf.sql.annotation.ExpectSelect;
+import org.quickperf.sql.annotation.ExpectSelects;
 
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
@@ -34,6 +35,18 @@ public class DisableQuickPerfFeaturesJUnit4Test {
         @ExpectSelect(5)
         @Test
         public void execute_one_select_but_five_select_expected() {
+            EntityManager em = emf.createEntityManager();
+            Query query = em.createQuery("FROM " + Book.class.getCanonicalName());
+            query.getResultList();
+        }
+
+        @DisableQuickPerf
+        @ExpectSelects({
+                @ExpectSelect(comment = "Select books"),
+                @ExpectSelect(comment = "Select related entities", value = 4)
+        })
+        @Test
+        public void execute_one_select_but_five_select_expected_with_repeated_annotations() {
             EntityManager em = emf.createEntityManager();
             Query query = em.createQuery("FROM " + Book.class.getCanonicalName());
             query.getResultList();
@@ -62,6 +75,18 @@ public class DisableQuickPerfFeaturesJUnit4Test {
         @ExpectSelect(5)
         @Test
         public void execute_one_select_but_five_select_expected() {
+            EntityManager em = emf.createEntityManager();
+            Query query = em.createQuery("FROM " + Book.class.getCanonicalName());
+            query.getResultList();
+        }
+
+        @FunctionalIteration
+        @ExpectSelects({
+                @ExpectSelect(comment = "Select books"),
+                @ExpectSelect(comment = "Select related entities", value = 4)
+        })
+        @Test
+        public void execute_one_select_but_five_select_expected_with_repeated_annotations() {
             EntityManager em = emf.createEntityManager();
             Query query = em.createQuery("FROM " + Book.class.getCanonicalName());
             query.getResultList();

--- a/junit4/junit4-sql-test/src/test/java/org/quickperf/sql/SqlConcurrencyJUnit4Test.java
+++ b/junit4/junit4-sql-test/src/test/java/org/quickperf/sql/SqlConcurrencyJUnit4Test.java
@@ -19,6 +19,7 @@ import org.junit.experimental.results.PrintableResult;
 import org.junit.runner.RunWith;
 import org.quickperf.junit4.QuickPerfJUnitRunner;
 import org.quickperf.sql.annotation.ExpectSelect;
+import org.quickperf.sql.annotation.ExpectSelects;
 
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
@@ -39,9 +40,21 @@ public class SqlConcurrencyJUnit4Test {
             query.getResultList();
         }
 
+        @ExpectSelects({
+                @ExpectSelect(comment = "Select books.")
+        })
+        @Test
+        public void execute_one_select_with_repeatable_annotation() {
+            EntityManager em = emf.createEntityManager();
+            Query query = em.createQuery("FROM " + Book.class.getCanonicalName());
+            query.getResultList();
+        }
+
     }
-    
-    @ThreadCount(100) @Test public void
+
+    @ThreadCount(100)
+    @Test
+    public void
     sql_performance_property_is_ok() {
 
         Class<?> testClass = AClassHavingAMethodWithoutSqlPerformanceIssue.class;

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/annotation/ExpectDelete.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/annotation/ExpectDelete.java
@@ -40,4 +40,10 @@ public @interface ExpectDelete {
      */
     int value() default 1;
 
+    /**
+     * To comment on the reason why we expect the specified amount of queries of this type.
+     * @return comment message
+     */
+    String comment() default "";
+
 }

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/annotation/ExpectDeletes.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/annotation/ExpectDeletes.java
@@ -18,33 +18,28 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * The <code>ExpectInsert</code> annotation verifies the number of executed insert statements corresponds to the
- * specified value.
+ * The <code>ExpectDeletes</code> annotation verifies the number of executed delete statements corresponds to the
+ * specified values.
  *
  * <br><br>
  * <h3>Example:</h3>
  * <pre>
- *      <b>&#064;ExpectInsert(6)</b>
- *      public void execute_six_insert() {
+ *      <b>&#064;ExpectDeletes({</b>
+ *          <b>&#064;ExpectDelete(comment="Delete user"),</b>
+ *          <b>&#064;ExpectDelete(comment="Delete posts",value=2)</b>
+ *      <b>})</b>
+ *      public void execute_three_delete() {
  *          <code>..</code>
  *      }
  * </pre>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
-public @interface ExpectInsert {
+public @interface ExpectDeletes {
 
     /**
-     * Specifies a <code>value</code> (integer) to cause test method to fail if the number of insert
-     * statements is not equal. Note that if left empty, the assumed value will be one.
+     * Specifies an array of expected queries.
      */
-
-    int value() default 1;
-
-    /**
-     * To comment on the reason why we expect the specified amount of queries of this type.
-     * @return comment message
-     */
-    String comment() default "";
+    ExpectDelete[] value();
 
 }

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/annotation/ExpectInserts.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/annotation/ExpectInserts.java
@@ -18,13 +18,17 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * The <code>ExpectInsert</code> annotation verifies the number of executed insert statements corresponds to the
- * specified value.
+ * The <code>ExpectInserts</code> annotation verifies the number of executed insert statements corresponds to the
+ * specified values.
  *
  * <br><br>
  * <h3>Example:</h3>
  * <pre>
- *      <b>&#064;ExpectInsert(6)</b>
+ *      <b>&#064;ExpectInserts({</b>
+ *          <b>&#064;ExpectInsert(comment="Insert user"),</b>
+ *          <b>&#064;ExpectInsert(comment="Insert posts",value=2),</b>
+ *          <b>&#064;ExpectInsert(comment="Insert comments",value=3)</b>
+ *      <b>})</b>
  *      public void execute_six_insert() {
  *          <code>..</code>
  *      }
@@ -32,19 +36,11 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
-public @interface ExpectInsert {
+public @interface ExpectInserts {
 
     /**
-     * Specifies a <code>value</code> (integer) to cause test method to fail if the number of insert
-     * statements is not equal. Note that if left empty, the assumed value will be one.
+     * Specifies an array of expected queries.
      */
-
-    int value() default 1;
-
-    /**
-     * To comment on the reason why we expect the specified amount of queries of this type.
-     * @return comment message
-     */
-    String comment() default "";
+    ExpectInsert[] value();
 
 }

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/annotation/ExpectJdbcQueryExecution.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/annotation/ExpectJdbcQueryExecution.java
@@ -40,4 +40,10 @@ public @interface ExpectJdbcQueryExecution {
      */
     int value() default 1;
 
+    /**
+     * To comment on the reason why we expect the specified amount of queries of this type.
+     * @return comment message
+     */
+    String comment() default "";
+
 }

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/annotation/ExpectSelect.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/annotation/ExpectSelect.java
@@ -40,4 +40,10 @@ public @interface ExpectSelect {
      */
     int value() default 1;
 
+    /**
+     * To comment on the reason why we expect the specified amount of queries of this type.
+     * @return comment message
+     */
+    String comment() default "";
+
 }

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/annotation/ExpectSelects.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/annotation/ExpectSelects.java
@@ -18,33 +18,28 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * The <code>ExpectInsert</code> annotation verifies the number of executed insert statements corresponds to the
- * specified value.
+ * The <code>ExpectSelects</code> annotation verifies the number of executed select statements corresponds to the
+ * specified values.
  *
  * <br><br>
  * <h3>Example:</h3>
  * <pre>
- *      <b>&#064;ExpectInsert(6)</b>
- *      public void execute_six_insert() {
+ *      <b>&#064;ExpectSelects({</b>
+ *          <b>&#064;ExpectSelect(comment="Load post"),</b>
+ *          <b>&#064;ExpectSelect(comment="Load comments",value=2)</b>
+ *      <b>})</b>
+ *      public void execute_three_selects() {
  *          <code>..</code>
  *      }
  * </pre>
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD})
-public @interface ExpectInsert {
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface ExpectSelects {
 
     /**
-     * Specifies a <code>value</code> (integer) to cause test method to fail if the number of insert
-     * statements is not equal. Note that if left empty, the assumed value will be one.
+     * Specifies an array of expected queries.
      */
-
-    int value() default 1;
-
-    /**
-     * To comment on the reason why we expect the specified amount of queries of this type.
-     * @return comment message
-     */
-    String comment() default "";
+    ExpectSelect[] value();
 
 }

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/annotation/ExpectUpdate.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/annotation/ExpectUpdate.java
@@ -40,4 +40,10 @@ public @interface ExpectUpdate {
      */
     int value() default 1;
 
+    /**
+     * To comment on the reason why we expect the specified amount of queries of this type.
+     * @return comment message
+     */
+    String comment() default "";
+
 }

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/annotation/ExpectUpdates.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/annotation/ExpectUpdates.java
@@ -18,33 +18,28 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * The <code>ExpectInsert</code> annotation verifies the number of executed insert statements corresponds to the
- * specified value.
+ * The <code>ExpectUpdates</code> annotation verifies the number of executed update statements corresponds to the
+ * specified values.
  *
  * <br><br>
  * <h3>Example:</h3>
  * <pre>
- *      <b>&#064;ExpectInsert(6)</b>
- *      public void execute_six_insert() {
+ *      <b>&#064;ExpectUpdates({</b>
+ *          <b>&#064;ExpectUpdate(comment="Update post"),</b>
+ *          <b>&#064;ExpectUpdate(comment="Update comments",value=2)</b>
+ *      <b>})</b>
+ *      public void execute_three_update() {
  *          <code>..</code>
  *      }
  * </pre>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
-public @interface ExpectInsert {
+public @interface ExpectUpdates {
 
     /**
-     * Specifies a <code>value</code> (integer) to cause test method to fail if the number of insert
-     * statements is not equal. Note that if left empty, the assumed value will be one.
+     * Specifies an array of expected queries.
      */
-
-    int value() default 1;
-
-    /**
-     * To comment on the reason why we expect the specified amount of queries of this type.
-     * @return comment message
-     */
-    String comment() default "";
+    ExpectUpdate[] value();
 
 }

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/annotation/SqlAnnotationBuilder.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/annotation/SqlAnnotationBuilder.java
@@ -134,6 +134,10 @@ public class SqlAnnotationBuilder {
             public int value() {
                 return value;
             }
+            @Override
+            public String comment() {
+                return "";
+            }
         };
     }
 

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/annotation/SqlAnnotationBuilder.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/annotation/SqlAnnotationBuilder.java
@@ -231,6 +231,10 @@ public class SqlAnnotationBuilder {
             public int value() {
                 return value;
             }
+            @Override
+            public String comment() {
+                return "";
+            }
         };
     }
 
@@ -246,6 +250,10 @@ public class SqlAnnotationBuilder {
             @Override
             public int value() {
                 return value;
+            }
+            @Override
+            public String comment() {
+                return "";
             }
         };
     }
@@ -263,6 +271,10 @@ public class SqlAnnotationBuilder {
             public int value() {
                 return value;
             }
+            @Override
+            public String comment() {
+                return "";
+            }
         };
     }
 
@@ -277,6 +289,74 @@ public class SqlAnnotationBuilder {
             }
             @Override
             public int value() {
+                return value;
+            }
+            @Override
+            public String comment() {
+                return "";
+            }
+        };
+    }
+
+    /**
+     *Allows to build {@link org.quickperf.sql.annotation.ExpectDeletes} annotation.
+     */
+    public static ExpectDeletes expectDeletes(final ExpectDelete... value) {
+        return new ExpectDeletes() {
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return ExpectDeletes.class;
+            }
+            @Override
+            public ExpectDelete[] value() {
+                return value;
+            }
+        };
+    }
+
+    /**
+     *Allows to build {@link org.quickperf.sql.annotation.ExpectInserts} annotation.
+     */
+    public static ExpectInserts expectInserts(final ExpectInsert... value) {
+        return new ExpectInserts() {
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return ExpectInserts.class;
+            }
+            @Override
+            public ExpectInsert[] value() {
+                return value;
+            }
+        };
+    }
+
+    /**
+     *Allows to build {@link org.quickperf.sql.annotation.ExpectSelects} annotation.
+     */
+    public static ExpectSelects expectSelects(final ExpectSelect... value) {
+        return new ExpectSelects() {
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return ExpectSelects.class;
+            }
+            @Override
+            public ExpectSelect[] value() {
+                return value;
+            }
+        };
+    }
+
+    /**
+     *Allows to build {@link org.quickperf.sql.annotation.ExpectUpdates} annotation.
+     */
+    public static ExpectUpdates expectUpdates(final ExpectUpdate... value) {
+        return new ExpectUpdates() {
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return ExpectUpdates.class;
+            }
+            @Override
+            public ExpectUpdate[] value() {
                 return value;
             }
         };

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/config/library/SqlAnnotationsConfigs.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/config/library/SqlAnnotationsConfigs.java
@@ -27,18 +27,17 @@ import org.quickperf.sql.connection.ProfilingParamsExtractor;
 import org.quickperf.sql.delete.DeleteCountMeasureExtractor;
 import org.quickperf.sql.delete.MaxOfDeletesPerfIssueVerifier;
 import org.quickperf.sql.delete.NumberOfSqlDeletePerfIssueVerifier;
+import org.quickperf.sql.delete.NumberOfSqlDeletesPerfIssueVerifier;
 import org.quickperf.sql.display.DisplaySqlOfTestMethodBodyRecorder;
 import org.quickperf.sql.display.DisplaySqlRecorder;
 import org.quickperf.sql.execution.*;
 import org.quickperf.sql.insert.InsertCountMeasureExtractor;
 import org.quickperf.sql.insert.InsertNumberPerfIssueVerifier;
 import org.quickperf.sql.insert.MaxOfInsertsPerfIssueVerifier;
+import org.quickperf.sql.insert.NumberOfSqlInsertsPerfIssueVerifier;
 import org.quickperf.sql.like.ContainsLikeWithLeadingWildcardExtractor;
 import org.quickperf.sql.like.HasLikeWithLeadingWildcardVerifier;
-import org.quickperf.sql.select.HasExactlySameSelectVerifier;
-import org.quickperf.sql.select.HasSameSelectTypesWithDiffParamValuesVerifier;
-import org.quickperf.sql.select.MaxOfSelectsPerfIssueVerifier;
-import org.quickperf.sql.select.SelectNumberPerfIssueVerifier;
+import org.quickperf.sql.select.*;
 import org.quickperf.sql.select.analysis.SelectAnalysisExtractor;
 import org.quickperf.sql.select.columns.MaxSelectedColumnsPerMeasureExtractor;
 import org.quickperf.sql.select.columns.MaxSelectedColumnsPerfIssueVerifier;
@@ -49,6 +48,7 @@ import org.quickperf.sql.statement.NoStatementVerifier;
 import org.quickperf.sql.time.SqlQueryExecutionTimeExtractor;
 import org.quickperf.sql.time.SqlQueryMaxExecutionTimeVerifier;
 import org.quickperf.sql.update.MaxOfUpdatesPerfIssueVerifier;
+import org.quickperf.sql.update.NumberOfSqlUpdatesPerfIssueVerifier;
 import org.quickperf.sql.update.UpdateCountMeasureExtractor;
 import org.quickperf.sql.update.UpdateNumberPerfIssueVerifier;
 import org.quickperf.sql.update.columns.MaxUpdatedColumnsPerMeasureExtractor;
@@ -87,6 +87,12 @@ class SqlAnnotationsConfigs {
             .perfMeasureExtractor(SelectAnalysisExtractor.INSTANCE)
             .perfIssueVerifier(SelectNumberPerfIssueVerifier.INSTANCE)
             .build(ExpectSelect.class);
+
+    static final AnnotationConfig NUMBER_OF_SQL_SELECTS = new AnnotationConfig.Builder()
+            .perfRecorderClass(PersistenceSqlRecorder.class)
+            .perfMeasureExtractor(SelectAnalysisExtractor.INSTANCE)
+            .perfIssueVerifier(NumberOfSqlSelectsPerfIssueVerifier.INSTANCE)
+            .build(ExpectSelects.class);
 
     static final AnnotationConfig MAX_SQL_SELECT = new AnnotationConfig.Builder()
             .perfRecorderClass(PersistenceSqlRecorder.class)
@@ -134,6 +140,12 @@ class SqlAnnotationsConfigs {
             .perfIssueVerifier(InsertNumberPerfIssueVerifier.INSTANCE)
             .build(ExpectInsert.class);
 
+    static final AnnotationConfig NUMBER_OF_SQL_INSERTS = new AnnotationConfig.Builder()
+            .perfRecorderClass(PersistenceSqlRecorder.class)
+            .perfMeasureExtractor(InsertCountMeasureExtractor.INSTANCE)
+            .perfIssueVerifier(NumberOfSqlInsertsPerfIssueVerifier.INSTANCE)
+            .build(ExpectInserts.class);
+
     static final AnnotationConfig SQL_STATEMENTS_BATCHED = new AnnotationConfig.Builder()
             .perfRecorderClass(SqlStatementBatchRecorder.class)
             .perfIssueVerifier(SqlStatementBatchVerifier.INSTANCE)
@@ -145,11 +157,23 @@ class SqlAnnotationsConfigs {
             .perfIssueVerifier(NumberOfSqlDeletePerfIssueVerifier.INSTANCE)
             .build(ExpectDelete.class);
 
+    static final AnnotationConfig NUMBER_OF_SQL_DELETES = new AnnotationConfig.Builder()
+            .perfRecorderClass(PersistenceSqlRecorder.class)
+            .perfMeasureExtractor(DeleteCountMeasureExtractor.INSTANCE)
+            .perfIssueVerifier(NumberOfSqlDeletesPerfIssueVerifier.INSTANCE)
+            .build(ExpectDeletes.class);
+
     static final AnnotationConfig NUMBER_OF_SQL_UPDATE = new AnnotationConfig.Builder()
             .perfRecorderClass(PersistenceSqlRecorder.class)
             .perfMeasureExtractor(UpdateCountMeasureExtractor.INSTANCE)
             .perfIssueVerifier(UpdateNumberPerfIssueVerifier.INSTANCE)
             .build(ExpectUpdate.class);
+
+    static final AnnotationConfig NUMBER_OF_SQL_UPDATES = new AnnotationConfig.Builder()
+            .perfRecorderClass(PersistenceSqlRecorder.class)
+            .perfMeasureExtractor(UpdateCountMeasureExtractor.INSTANCE)
+            .perfIssueVerifier(NumberOfSqlUpdatesPerfIssueVerifier.INSTANCE)
+            .build(ExpectUpdates.class);
 
 	static final AnnotationConfig MAX_SQL_UPDATE = new AnnotationConfig.Builder()
 			.perfRecorderClass(PersistenceSqlRecorder.class)

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/config/library/SqlConfigLoader.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/config/library/SqlConfigLoader.java
@@ -33,9 +33,13 @@ public class SqlConfigLoader implements QuickPerfConfigLoader {
                   SqlAnnotationsConfigs.JDBC_QUERY_EXECUTION
                 , SqlAnnotationsConfigs.MAX_JDBC_QUERY_EXECUTION
                 , SqlAnnotationsConfigs.NUMBER_OF_SQL_SELECT
+                , SqlAnnotationsConfigs.NUMBER_OF_SQL_SELECTS
                 , SqlAnnotationsConfigs.NUMBER_OF_SQL_INSERT
+                , SqlAnnotationsConfigs.NUMBER_OF_SQL_INSERTS
                 , SqlAnnotationsConfigs.NUMBER_OF_SQL_UPDATE
+                , SqlAnnotationsConfigs.NUMBER_OF_SQL_UPDATES
                 , SqlAnnotationsConfigs.NUMBER_OF_SQL_DELETE
+                , SqlAnnotationsConfigs.NUMBER_OF_SQL_DELETES
                 , SqlAnnotationsConfigs.MAX_SQL_SELECT
                 , SqlAnnotationsConfigs.MAX_SQL_INSERT
                 , SqlAnnotationsConfigs.MAX_SQL_UPDATE

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/delete/NumberOfSqlDeletesPerfIssueVerifier.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/delete/NumberOfSqlDeletesPerfIssueVerifier.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2022 the original author or authors.
+ */
+package org.quickperf.sql.delete;
+
+import org.quickperf.issue.PerfIssue;
+import org.quickperf.issue.VerifiablePerformanceIssue;
+import org.quickperf.sql.annotation.ExpectDelete;
+import org.quickperf.sql.annotation.ExpectDeletes;
+import org.quickperf.unit.Count;
+
+import java.util.Arrays;
+
+import static org.quickperf.sql.SqlStatementPerfIssueBuilder.aSqlPerfIssue;
+
+public class NumberOfSqlDeletesPerfIssueVerifier implements VerifiablePerformanceIssue<ExpectDeletes, Count> {
+
+    public static final NumberOfSqlDeletesPerfIssueVerifier INSTANCE = new NumberOfSqlDeletesPerfIssueVerifier();
+
+    private NumberOfSqlDeletesPerfIssueVerifier() {
+    }
+
+    @Override
+    public PerfIssue verifyPerfIssue(final ExpectDeletes annotation, final Count measuredCount) {
+
+        int sum = 0;
+        for (ExpectDelete expectDelete : annotation.value()) {
+            sum += expectDelete.value();
+        }
+        final Count expectedCount = new Count(sum);
+
+        if (!measuredCount.isEqualTo(expectedCount)) {
+            return aSqlPerfIssue().buildNotEqualNumberOfStatements(
+                    measuredCount, expectedCount, "DELETE");
+        }
+
+        return PerfIssue.NONE;
+
+    }
+
+}

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/insert/NumberOfSqlInsertsPerfIssueVerifier.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/insert/NumberOfSqlInsertsPerfIssueVerifier.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2022 the original author or authors.
+ */
+package org.quickperf.sql.insert;
+
+import org.quickperf.issue.PerfIssue;
+import org.quickperf.issue.VerifiablePerformanceIssue;
+import org.quickperf.sql.annotation.ExpectInsert;
+import org.quickperf.sql.annotation.ExpectInserts;
+import org.quickperf.unit.Count;
+
+import java.util.Arrays;
+
+import static org.quickperf.sql.SqlStatementPerfIssueBuilder.aSqlPerfIssue;
+
+public class NumberOfSqlInsertsPerfIssueVerifier implements VerifiablePerformanceIssue<ExpectInserts, Count> {
+
+    public static final NumberOfSqlInsertsPerfIssueVerifier INSTANCE = new NumberOfSqlInsertsPerfIssueVerifier();
+
+    private NumberOfSqlInsertsPerfIssueVerifier() {
+    }
+
+    @Override
+    public PerfIssue verifyPerfIssue(final ExpectInserts annotation, final Count measuredCount) {
+
+        int sum = 0;
+        for (ExpectInsert expectInsert : annotation.value()) {
+            sum += expectInsert.value();
+        }
+        final Count expectedCount = new Count(sum);
+
+        if (!measuredCount.isEqualTo(expectedCount)) {
+            return aSqlPerfIssue().buildNotEqualNumberOfStatements(
+                    measuredCount, expectedCount, "INSERT");
+        }
+
+        return PerfIssue.NONE;
+
+    }
+
+}

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/select/NumberOfSqlSelectsPerfIssueVerifier.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/select/NumberOfSqlSelectsPerfIssueVerifier.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2022 the original author or authors.
+ */
+package org.quickperf.sql.select;
+
+import org.quickperf.issue.PerfIssue;
+import org.quickperf.issue.VerifiablePerformanceIssue;
+import org.quickperf.sql.annotation.ExpectSelect;
+import org.quickperf.sql.annotation.ExpectSelects;
+import org.quickperf.sql.select.analysis.SelectAnalysis;
+import org.quickperf.unit.Count;
+
+import java.util.Arrays;
+
+import static org.quickperf.sql.SqlStatementPerfIssueBuilder.aSqlPerfIssue;
+
+public class NumberOfSqlSelectsPerfIssueVerifier implements VerifiablePerformanceIssue<ExpectSelects, SelectAnalysis> {
+
+    public static final NumberOfSqlSelectsPerfIssueVerifier INSTANCE = new NumberOfSqlSelectsPerfIssueVerifier();
+
+    private NumberOfSqlSelectsPerfIssueVerifier() {
+    }
+
+    @Override
+    public PerfIssue verifyPerfIssue(final ExpectSelects annotation, final SelectAnalysis analysis) {
+
+        int sum = 0;
+        for (ExpectSelect expectSelect : annotation.value()) {
+            sum += expectSelect.value();
+        }
+        final Count expectedCount = new Count(sum);
+
+        final Count measuredCount = analysis.getSelectNumber();
+        if (!measuredCount.isEqualTo(expectedCount)) {
+            return aSqlPerfIssue().buildNotEqualNumberOfStatements(
+                    measuredCount, expectedCount, "SELECT");
+        }
+
+        return PerfIssue.NONE;
+
+    }
+
+}

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/update/NumberOfSqlUpdatesPerfIssueVerifier.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/update/NumberOfSqlUpdatesPerfIssueVerifier.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2022 the original author or authors.
+ */
+package org.quickperf.sql.update;
+
+import org.quickperf.issue.PerfIssue;
+import org.quickperf.issue.VerifiablePerformanceIssue;
+import org.quickperf.sql.annotation.ExpectUpdate;
+import org.quickperf.sql.annotation.ExpectUpdates;
+import org.quickperf.unit.Count;
+
+import java.util.Arrays;
+
+import static org.quickperf.sql.SqlStatementPerfIssueBuilder.aSqlPerfIssue;
+
+public class NumberOfSqlUpdatesPerfIssueVerifier implements VerifiablePerformanceIssue<ExpectUpdates, Count> {
+
+    public static final NumberOfSqlUpdatesPerfIssueVerifier INSTANCE = new NumberOfSqlUpdatesPerfIssueVerifier();
+
+    private NumberOfSqlUpdatesPerfIssueVerifier() {
+    }
+
+    @Override
+    public PerfIssue verifyPerfIssue(final ExpectUpdates annotation, final Count measuredCount) {
+
+        int sum = 0;
+        for (ExpectUpdate expectUpdate : annotation.value()) {
+            sum += expectUpdate.value();
+        }
+        final Count expectedCount = new Count(sum);
+
+        if (!measuredCount.isEqualTo(expectedCount)) {
+            return aSqlPerfIssue().buildNotEqualNumberOfStatements(
+                    measuredCount, expectedCount, "UPDATE");
+        }
+
+        return PerfIssue.NONE;
+
+    }
+
+}


### PR DESCRIPTION
- Add new repeated ExpectSelect/ExpectInsert/ExpectUpdate/ExpectDelete annotation variants
- Include optional comment in ExpectSelect/ExpectInsert/ExpectUpdate/ExpectDelete/ExpectJdbcQueryExecution
- Add and register new verifiers
- Add new test cases

Resolves #222 