### PR TITLE
Add @DataJpaTest support for Spring Boot

### DIFF
--- a/spring/junit4-spring-boot-1-test/pom.xml
+++ b/spring/junit4-spring-boot-1-test/pom.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+  ~ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+  ~
+  ~ Copyright 2019-2022 the original author or authors.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.quickperf</groupId>
+        <artifactId>quick-perf-spring</artifactId>
+        <version>1.1.1-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quick-perf-junit4-spring-boot-1-test</artifactId>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <dependencies.max.jdk.version>1.8</dependencies.max.jdk.version>
+        <maven.install.skip>true</maven.install.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <gpg.skip>true</gpg.skip>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>1.5.21.RELEASE</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-bom</artifactId>
+                <version>2.17.1</version>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.quickperf</groupId>
+            <artifactId>quick-perf-junit4-spring4</artifactId>
+            <version>1.1.1-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.quickperf</groupId>
+            <artifactId>quick-perf-springboot1-sql-starter</artifactId>
+            <version>1.1.1-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-log4j2</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <version>2.4.0</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven-jar-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/spring/junit4-spring-boot-1-test/src/main/java/org/quickperf/spring/springboottest/FootballApplication.java
+++ b/spring/junit4-spring-boot-1-test/src/main/java/org/quickperf/spring/springboottest/FootballApplication.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2022 the original author or authors.
+ */
+package org.quickperf.spring.springboottest;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class FootballApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(FootballApplication.class, args);
+    }
+
+}

--- a/spring/junit4-spring-boot-1-test/src/main/java/org/quickperf/spring/springboottest/jpa/entity/Player.java
+++ b/spring/junit4-spring-boot-1-test/src/main/java/org/quickperf/spring/springboottest/jpa/entity/Player.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2022 the original author or authors.
+ */
+package org.quickperf.spring.springboottest.jpa.entity;
+
+import javax.persistence.*;
+import java.io.Serializable;
+
+@Entity
+public class Player implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String firstName;
+
+    private String lastName;
+
+    @ManyToOne(fetch = FetchType.LAZY, targetEntity = Team.class)
+    @JoinColumn(name = "team_id")
+    private Team team;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public Team getTeam() {
+        return team;
+    }
+
+    public void setTeam(Team team) {
+        this.team = team;
+    }
+
+}

--- a/spring/junit4-spring-boot-1-test/src/main/java/org/quickperf/spring/springboottest/jpa/entity/Team.java
+++ b/spring/junit4-spring-boot-1-test/src/main/java/org/quickperf/spring/springboottest/jpa/entity/Team.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2022 the original author or authors.
+ */
+package org.quickperf.spring.springboottest.jpa.entity;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import java.io.Serializable;
+
+@Entity
+public class Team implements Serializable {
+
+    @Id
+    private Long id;
+
+    private String name;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+}

--- a/spring/junit4-spring-boot-1-test/src/main/java/org/quickperf/spring/springboottest/jpa/repository/PlayerRepository.java
+++ b/spring/junit4-spring-boot-1-test/src/main/java/org/quickperf/spring/springboottest/jpa/repository/PlayerRepository.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2022 the original author or authors.
+ */
+package org.quickperf.spring.springboottest.jpa.repository;
+
+import org.quickperf.spring.springboottest.jpa.entity.Player;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PlayerRepository extends JpaRepository<Player, Long> {
+
+    List<Player> findAll();
+
+}

--- a/spring/junit4-spring-boot-1-test/src/test/java/org/quickperf/spring/springboottest/SpringBoot1Junit4DataJpaTest.java
+++ b/spring/junit4-spring-boot-1-test/src/test/java/org/quickperf/spring/springboottest/SpringBoot1Junit4DataJpaTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2022 the original author or authors.
+ */
+package org.quickperf.spring.springboottest;
+
+import org.junit.Test;
+import org.junit.experimental.results.PrintableResult;
+import org.quickperf.spring.springboottest.datajpatest.DetectionOfNPlusOneSelectWithDataJpa;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SpringBoot1Junit4DataJpaTest {
+
+    @Test
+    public void should_detect_select_with_datajpatest() {
+
+        // GIVEN
+        Class<?> testClass = DetectionOfNPlusOneSelectWithDataJpa.class;
+
+        // WHEN
+        PrintableResult printableResult = PrintableResult.testResult(testClass);
+
+        // THEN
+        assertThat(printableResult.failureCount()).isOne();
+
+        String testReport = printableResult.toString();
+        assertThat(testReport)
+                      .contains("You may think that <1> select statement was sent to the database")
+                      .contains("Perhaps you are facing an N+1 select issue");
+
+    }
+
+}

--- a/spring/junit4-spring-boot-1-test/src/test/java/org/quickperf/spring/springboottest/datajpatest/DetectionOfNPlusOneSelectWithDataJpa.java
+++ b/spring/junit4-spring-boot-1-test/src/test/java/org/quickperf/spring/springboottest/datajpatest/DetectionOfNPlusOneSelectWithDataJpa.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2022 the original author or authors.
+ */
+package org.quickperf.spring.springboottest.datajpatest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.quickperf.spring.junit4.QuickPerfSpringRunner;
+import org.quickperf.spring.springboottest.jpa.entity.Player;
+import org.quickperf.spring.springboottest.jpa.repository.PlayerRepository;
+import org.quickperf.sql.annotation.ExpectSelect;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(QuickPerfSpringRunner.class)
+@DataJpaTest
+public class DetectionOfNPlusOneSelectWithDataJpa {
+
+    @Autowired
+    private PlayerRepository playerRepository;
+
+    @ExpectSelect(1)
+    @Test
+    public void should_find_all_players_with_team_name() {
+
+        List<Player> players = playerRepository.findAll();
+
+        List<String> teamNames = players.stream()
+                .map(player -> player.getTeam().getName())
+                .collect(Collectors.toList());
+
+        assertThat(teamNames).hasSize(2);
+
+    }
+
+}

--- a/spring/junit4-spring-boot-1-test/src/test/resources/application.properties
+++ b/spring/junit4-spring-boot-1-test/src/test/resources/application.properties
@@ -1,0 +1,19 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+# Copyright 2019-2022 the original author or authors.
+#
+
+spring.datasource.url=jdbc:hsqldb:mem:myDb;sql.syntax_pgs=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.HSQLDialect
+
+logging.level.org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl=ERROR
+
+spring.main.banner-mode=off

--- a/spring/junit4-spring-boot-1-test/src/test/resources/import.sql
+++ b/spring/junit4-spring-boot-1-test/src/test/resources/import.sql
@@ -1,0 +1,18 @@
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+-- the License. You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+-- an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations under the License.
+--
+-- Copyright 2019-2022 the original author or authors.
+--
+
+INSERT INTO TEAM VALUES (1, 'Manchester United');
+INSERT INTO TEAM VALUES (2, 'Atlético de Madrid');
+
+INSERT INTO PLAYER VALUES (1, 'Paul', 'Pogba', 1);
+INSERT INTO PLAYER VALUES (2, 'Antoine', 'Griezmann', 2);

--- a/spring/junit4-spring-boot-1-test/src/test/resources/log4j2.xml
+++ b/spring/junit4-spring-boot-1-test/src/test/resources/log4j2.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+    the License. You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations under the License.
+
+    Copyright 2019-2022 the original author or authors.
+
+-->
+<Configuration status="WARN" monitorInterval="30">
+    <Appenders>
+        <Console name="ConsoleAppender" target="SYSTEM_OUT" follow="true">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %5p --- [%15.15t] %-40.40c{1.} : %m%n%ex"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="warn">
+            <!-- Logging disabled to not pollute build output -->
+        </Root>
+    </Loggers>
+</Configuration>

--- a/spring/junit4-spring-boot-test/src/test/java/org/quickperf/spring/springboottest/SpringBoot2JUnit4DataJpaTest.java
+++ b/spring/junit4-spring-boot-test/src/test/java/org/quickperf/spring/springboottest/SpringBoot2JUnit4DataJpaTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2022 the original author or authors.
+ */
+package org.quickperf.spring.springboottest;
+
+import org.junit.Test;
+import org.junit.experimental.results.PrintableResult;
+import org.quickperf.spring.springboottest.datajpatest.DetectionOfNPlusOneSelectWithDataJpa;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SpringBoot2JUnit4DataJpaTest {
+
+    @Test
+    public void should_detect_select_with_datajpatest() {
+
+        // GIVEN
+        Class<?> testClass = DetectionOfNPlusOneSelectWithDataJpa.class;
+
+        // WHEN
+        PrintableResult printableResult = PrintableResult.testResult(testClass);
+
+        // THEN
+        assertThat(printableResult.failureCount()).isOne();
+
+        String testReport = printableResult.toString();
+        assertThat(testReport)
+                      .contains("You may think that <1> select statement was sent to the database")
+                      .contains("Perhaps you are facing an N+1 select issue");
+
+    }
+
+}

--- a/spring/junit4-spring-boot-test/src/test/java/org/quickperf/spring/springboottest/datajpatest/DetectionOfNPlusOneSelectWithDataJpa.java
+++ b/spring/junit4-spring-boot-test/src/test/java/org/quickperf/spring/springboottest/datajpatest/DetectionOfNPlusOneSelectWithDataJpa.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2022 the original author or authors.
+ */
+package org.quickperf.spring.springboottest.datajpatest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.quickperf.spring.junit4.QuickPerfSpringRunner;
+import org.quickperf.spring.springboottest.jpa.entity.Player;
+import org.quickperf.spring.springboottest.jpa.repository.PlayerRepository;
+import org.quickperf.sql.annotation.ExpectSelect;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(QuickPerfSpringRunner.class)
+@DataJpaTest
+public class DetectionOfNPlusOneSelectWithDataJpa {
+
+    @Autowired
+    private PlayerRepository playerRepository;
+
+    @ExpectSelect(1)
+    @Test
+    public void should_find_all_players_with_team_name() {
+
+        List<Player> players = playerRepository.findAll();
+
+        List<String> teamNames = players.stream()
+                .map(player -> player.getTeam().getName())
+                .collect(Collectors.toList());
+
+        assertThat(teamNames).hasSize(2);
+
+    }
+
+}

--- a/spring/junit5-spring-boot-3-test/src/test/java/org/quickperf/spring/springboottest/SpringBoot3JUnit5DataJpaTest.java
+++ b/spring/junit5-spring-boot-3-test/src/test/java/org/quickperf/spring/springboottest/SpringBoot3JUnit5DataJpaTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2022 the original author or authors.
+ */
+package org.quickperf.spring.springboottest;
+
+import org.junit.jupiter.api.Test;
+import org.quickperf.junit5.JUnit5Tests;
+import org.quickperf.junit5.JUnit5Tests.JUnit5TestsResult;
+import org.quickperf.spring.springboottest.datajpatest.DetectionOfNPlusOneSelectWithDataJpa;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SpringBoot3JUnit5DataJpaTest {
+
+    @Test
+    void should_detect_select_with_data_jpa_test() {
+
+        // GIVEN
+        Class<?> testClass = DetectionOfNPlusOneSelectWithDataJpa.class;
+        JUnit5Tests jUnit5Tests = JUnit5Tests.createInstance(testClass);
+
+        // WHEN
+        JUnit5TestsResult jUnit5TestsResult = jUnit5Tests.run();
+
+        // THEN
+        assertThat(jUnit5TestsResult.getNumberOfFailures()).isOne();
+
+        String errorReport = jUnit5TestsResult.getErrorReport();
+        assertThat(errorReport)
+                      .contains("You may think that <1> select statement was sent to the database")
+                      .contains("Perhaps you are facing an N+1 select issue");
+
+    }
+
+}

--- a/spring/junit5-spring-boot-3-test/src/test/java/org/quickperf/spring/springboottest/datajpatest/DetectionOfNPlusOneSelectWithDataJpa.java
+++ b/spring/junit5-spring-boot-3-test/src/test/java/org/quickperf/spring/springboottest/datajpatest/DetectionOfNPlusOneSelectWithDataJpa.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2022 the original author or authors.
+ */
+package org.quickperf.spring.springboottest.datajpatest;
+
+import org.junit.jupiter.api.Test;
+import org.quickperf.junit5.QuickPerfTest;
+import org.quickperf.spring.springboottest.jpa.entity.Player;
+import org.quickperf.spring.springboottest.jpa.repository.PlayerRepository;
+import org.quickperf.sql.annotation.ExpectSelect;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuickPerfTest
+@DataJpaTest
+public class DetectionOfNPlusOneSelectWithDataJpa {
+
+    @Autowired
+    private PlayerRepository playerRepository;
+
+    @ExpectSelect(1)
+    @Test
+    public void should_find_all_players_with_team_name() {
+
+        List<Player> players = playerRepository.findAll();
+
+        List<String> teamNames = players.stream()
+                .map(player -> player.getTeam().getName())
+                .collect(Collectors.toList());
+
+        assertThat(teamNames).hasSize(2);
+
+    }
+
+}

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -50,6 +50,15 @@
             </modules>
         </profile>
         <profile>
+            <id>SpringBoot1Tests</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <modules>
+                <module>junit4-spring-boot-1-test</module>
+            </modules>
+        </profile>
+        <profile>
             <id>SpringBoot3Tests</id>
             <activation>
                 <jdk>[17,)</jdk>

--- a/spring/spring-boot-1-sql-starter/src/main/resources/META-INF/spring.factories
+++ b/spring/spring-boot-1-sql-starter/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,5 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 org.quickperf.spring.boot.QuickPerfProxyBeanAutoConfiguration
+
+org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa=\
+org.quickperf.spring.boot.QuickPerfProxyBeanAutoConfiguration

--- a/spring/spring-boot-2-sql-starter/src/main/resources/META-INF/spring.factories
+++ b/spring/spring-boot-2-sql-starter/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,5 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 org.quickperf.spring.boot.QuickPerfProxyBeanAutoConfiguration
+
+org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa=\
+org.quickperf.spring.boot.QuickPerfProxyBeanAutoConfiguration

--- a/spring/spring-boot-2-sql-starter/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa.imports
+++ b/spring/spring-boot-2-sql-starter/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa.imports
@@ -1,0 +1,1 @@
+org.quickperf.spring.boot.QuickPerfProxyBeanAutoConfiguration

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/framework/ClassPath.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/framework/ClassPath.java
@@ -49,6 +49,10 @@ public class ClassPath {
         return value.contains("spring-boot-2");
     }
 
+    public boolean containsSpringBoot3() {
+        return value.contains("spring-boot-3");
+    }
+
     public boolean containsSpringCore() {
         return containsSpringframework() && value.contains("spring-core");
     }

--- a/sql/sql-annotations/src/main/java/org/quickperf/sql/framework/quickperf/SpringDataSourceConfig.java
+++ b/sql/sql-annotations/src/main/java/org/quickperf/sql/framework/quickperf/SpringDataSourceConfig.java
@@ -32,19 +32,15 @@ class SpringDataSourceConfig implements QuickPerfSuggestion {
 
         if (classPath.containsSpringBoot1()) {
             if (classPath.contains(QUICKPERF_SPRING_BOOT_1_SQL_STARTER)) {
-                return    buildDataJpaTestAnnotationMessage()
-                        + LINE_SEPARATOR
-                        + LINE_SEPARATOR + buildSpringRESTControllerMessage();
+                return LINE_SEPARATOR + buildSpringRESTControllerMessage();
             }
             return "To configure it, add the following dependency: "
                   + LINE_SEPARATOR + format(QUICKPERF_SPRING_BOOT_1_SQL_STARTER);
         }
 
-        if (classPath.containsSpringBoot2()) {
+        if (classPath.containsSpringBoot2() || classPath.containsSpringBoot3()) {
             if (classPath.contains(QUICKPERF_SPRING_BOOT_2_SQL_STARTER)) {
-                return    buildDataJpaTestAnnotationMessage()
-                        + LINE_SEPARATOR
-                        + LINE_SEPARATOR + buildSpringRESTControllerMessage();
+                return LINE_SEPARATOR + buildSpringRESTControllerMessage();
             }
             return   "To configure it, add the following dependency: "
                     + LINE_SEPARATOR + format(QUICKPERF_SPRING_BOOT_2_SQL_STARTER);
@@ -78,16 +74,6 @@ class SpringDataSourceConfig implements QuickPerfSuggestion {
 
         return "";
 
-    }
-
-    private String buildDataJpaTestAnnotationMessage() {
-        return    "Do you use @DataJpaTest? This annotation disables Spring auto-configuration."
-                + LINE_SEPARATOR + "So, QuickPerf Spring auto-configuration is disabled."
-                + LINE_SEPARATOR + "To allow QuickPerf to intercept the SQL queries, you have two possibilities: "
-                + LINE_SEPARATOR + "1) Import QuickPerfSqlConfig (recommended): "
-                + LINE_SEPARATOR + buildImportQuickPerfSqlConfigExample()
-                + LINE_SEPARATOR + "2) Force to enable Spring auto-configuration by adding"
-                + LINE_SEPARATOR + "   " + "@OverrideAutoConfiguration(enabled = true) on the test class";
     }
 
     private String buildSpringRESTControllerMessage() {


### PR DESCRIPTION
Before, using QuickPerf with `@DataJpaTest` required extra configuration on the test class:

```java
@DataJpaTest
@Import(QuickPerfSqlConfig.class)
```
or
```java
@DataJpaTest
@OverrideAutoConfiguration(enabled = true)
```