### PR TITLE
Add @DataJdbcTest support for Spring Boot

### DIFF
--- a/spring/junit4-spring-boot-test/src/test/java/org/quickperf/spring/springboottest/SpringBoot2JUnit4DataJdbcTest.java
+++ b/spring/junit4-spring-boot-test/src/test/java/org/quickperf/spring/springboottest/SpringBoot2JUnit4DataJdbcTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2022 the original author or authors.
+ */
+package org.quickperf.spring.springboottest;
+
+import org.junit.Test;
+import org.junit.experimental.results.PrintableResult;
+import org.quickperf.spring.springboottest.datajdbctest.ExpectSelectWithDataJdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SpringBoot2JUnit4DataJdbcTest {
+
+    @Test
+    public void should_detect_select_with_datajdbctest() {
+
+       // GIVEN
+        Class<?> testClass = ExpectSelectWithDataJdbc.class;
+
+        // WHEN
+        PrintableResult printableResult = PrintableResult.testResult(testClass);
+
+        // THEN
+        assertThat(printableResult.failureCount()).isOne();
+
+        String testReport = printableResult.toString();
+        assertThat(testReport)
+                      .contains("You may think that <1> select statement was sent to the database")
+                      .contains("Perhaps you are facing an N+1 select issue");
+
+    }
+
+}

--- a/spring/junit4-spring-boot-test/src/test/java/org/quickperf/spring/springboottest/datajdbctest/ExpectSelectWithDataJdbc.java
+++ b/spring/junit4-spring-boot-test/src/test/java/org/quickperf/spring/springboottest/datajdbctest/ExpectSelectWithDataJdbc.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2022 the original author or authors.
+ */
+package org.quickperf.spring.springboottest.datajdbctest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.quickperf.spring.junit4.QuickPerfSpringRunner;
+import org.quickperf.sql.annotation.ExpectSelect;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.jdbc.Sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(QuickPerfSpringRunner.class)
+@DataJdbcTest
+@Sql(statements = {
+        "CREATE TABLE IF NOT EXISTS PLAYER_DATA_JDBC_TEST (id BIGINT PRIMARY KEY, name VARCHAR(255))",
+        "INSERT INTO PLAYER_DATA_JDBC_TEST VALUES (1, 'Paul Pogba')",
+        "INSERT INTO PLAYER_DATA_JDBC_TEST VALUES (2, 'Antoine Griezmann')"
+})
+public class ExpectSelectWithDataJdbc {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @ExpectSelect(1)
+    @Test
+    public void should_detect_two_selects() {
+
+        java.util.List<java.util.Map<String, Object>> player1 =
+                jdbcTemplate.queryForList("SELECT id, name FROM PLAYER_DATA_JDBC_TEST WHERE id = 1");
+
+        java.util.List<java.util.Map<String, Object>> player2 =
+                jdbcTemplate.queryForList("SELECT id, name FROM PLAYER_DATA_JDBC_TEST WHERE id = 2");
+
+        assertThat(player1).hasSize(1);
+        assertThat(player2).hasSize(1);
+
+    }
+
+}

--- a/spring/junit5-spring-boot-3-test/pom.xml
+++ b/spring/junit5-spring-boot-3-test/pom.xml
@@ -87,6 +87,11 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jdbc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 

--- a/spring/junit5-spring-boot-3-test/src/test/java/org/quickperf/spring/springboottest/SpringBoot3JUnit5DataJdbcTest.java
+++ b/spring/junit5-spring-boot-3-test/src/test/java/org/quickperf/spring/springboottest/SpringBoot3JUnit5DataJdbcTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2022 the original author or authors.
+ */
+package org.quickperf.spring.springboottest;
+
+import org.junit.jupiter.api.Test;
+import org.quickperf.junit5.JUnit5Tests;
+import org.quickperf.junit5.JUnit5Tests.JUnit5TestsResult;
+import org.quickperf.spring.springboottest.datajdbctest.ExpectSelectWithDataJdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SpringBoot3JUnit5DataJdbcTest {
+
+    @Test
+    void should_detect_select_with_data_jdbc_test() {
+
+        // GIVEN
+        Class<?> testClass = ExpectSelectWithDataJdbc.class;
+        JUnit5Tests jUnit5Tests = JUnit5Tests.createInstance(testClass);
+
+        // WHEN
+        JUnit5TestsResult jUnit5TestsResult = jUnit5Tests.run();
+
+        // THEN
+        assertThat(jUnit5TestsResult.getNumberOfFailures()).isOne();
+
+        String errorReport = jUnit5TestsResult.getErrorReport();
+        assertThat(errorReport)
+                      .contains("You may think that <1> select statement was sent to the database")
+                      .contains("Perhaps you are facing an N+1 select issue");
+
+    }
+
+}

--- a/spring/junit5-spring-boot-3-test/src/test/java/org/quickperf/spring/springboottest/datajdbctest/ExpectSelectWithDataJdbc.java
+++ b/spring/junit5-spring-boot-3-test/src/test/java/org/quickperf/spring/springboottest/datajdbctest/ExpectSelectWithDataJdbc.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2022 the original author or authors.
+ */
+package org.quickperf.spring.springboottest.datajdbctest;
+
+import org.junit.jupiter.api.Test;
+import org.quickperf.junit5.QuickPerfTest;
+import org.quickperf.sql.annotation.ExpectSelect;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.jdbc.Sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuickPerfTest
+@DataJdbcTest
+@Sql(statements = {
+        "CREATE TABLE IF NOT EXISTS PLAYER_DATA_JDBC_TEST (id BIGINT PRIMARY KEY, name VARCHAR(255))",
+        "INSERT INTO PLAYER_DATA_JDBC_TEST VALUES (1, 'Paul Pogba')",
+        "INSERT INTO PLAYER_DATA_JDBC_TEST VALUES (2, 'Antoine Griezmann')"
+})
+public class ExpectSelectWithDataJdbc {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @ExpectSelect(1)
+    @Test
+    public void should_detect_two_selects() {
+
+        java.util.List<java.util.Map<String, Object>> player1 =
+                jdbcTemplate.queryForList("SELECT id, name FROM PLAYER_DATA_JDBC_TEST WHERE id = 1");
+
+        java.util.List<java.util.Map<String, Object>> player2 =
+                jdbcTemplate.queryForList("SELECT id, name FROM PLAYER_DATA_JDBC_TEST WHERE id = 2");
+
+        assertThat(player1).hasSize(1);
+        assertThat(player2).hasSize(1);
+
+    }
+
+}

--- a/spring/spring-boot-2-sql-starter/src/main/resources/META-INF/spring.factories
+++ b/spring/spring-boot-2-sql-starter/src/main/resources/META-INF/spring.factories
@@ -6,3 +6,6 @@ org.quickperf.spring.boot.QuickPerfProxyBeanAutoConfiguration
 
 org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureJdbc=\
 org.quickperf.spring.boot.QuickPerfProxyBeanAutoConfiguration
+
+org.springframework.boot.test.autoconfigure.data.jdbc.AutoConfigureDataJdbc=\
+org.quickperf.spring.boot.QuickPerfProxyBeanAutoConfiguration

--- a/spring/spring-boot-2-sql-starter/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.data.jdbc.AutoConfigureDataJdbc.imports
+++ b/spring/spring-boot-2-sql-starter/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.data.jdbc.AutoConfigureDataJdbc.imports
@@ -1,0 +1,1 @@
+org.quickperf.spring.boot.QuickPerfProxyBeanAutoConfiguration


### PR DESCRIPTION
Before, using QuickPerf with `@DataJdbcTest` required extra configuration on the test class:

```java
@DataJdbcTest
@Import(QuickPerfSqlConfig.class)
```
or
```java
@DataJdbcTest
@OverrideAutoConfiguration(enabled = true)
```