### PR TITLE
Fix Spring BeanPostProcessor DataSource proxy ordering

### DIFF
--- a/spring/junit4-spring-boot-1-test/src/test/java/org/quickperf/spring/springboottest/SpringBoot1BeanPostProcessorWithDataSourceDependencyJunit4Test.java
+++ b/spring/junit4-spring-boot-1-test/src/test/java/org/quickperf/spring/springboottest/SpringBoot1BeanPostProcessorWithDataSourceDependencyJunit4Test.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2022 the original author or authors.
+ */
+package org.quickperf.spring.springboottest;
+
+import org.junit.Test;
+import org.junit.experimental.results.PrintableResult;
+import org.quickperf.spring.springboottest.beanPostProcessor.BeanPostProcessorWithDataSourceDependency;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SpringBoot1BeanPostProcessorWithDataSourceDependencyJunit4Test {
+
+    @Test
+    public void should_fail_if_select_number_is_different_from_expected_even_when_other_bean_post_processor_depends_on_datasource() {
+
+        // GIVEN
+        Class<?> testClass = BeanPostProcessorWithDataSourceDependency.class;
+
+        // WHEN
+        PrintableResult printableResult = PrintableResult.testResult(testClass);
+
+        // THEN
+        assertThat(printableResult.failureCount()).isOne();
+
+        String testReport = printableResult.toString();
+        assertThat(testReport)
+                      .contains("You may think that <2> select statements were sent to the database")
+                      .contains("But there is in fact <1>");
+
+    }
+
+}

--- a/spring/junit4-spring-boot-1-test/src/test/java/org/quickperf/spring/springboottest/beanPostProcessor/BeanPostProcessorWithDataSourceDependency.java
+++ b/spring/junit4-spring-boot-1-test/src/test/java/org/quickperf/spring/springboottest/beanPostProcessor/BeanPostProcessorWithDataSourceDependency.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2022 the original author or authors.
+ */
+package org.quickperf.spring.springboottest.beanPostProcessor;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.quickperf.spring.junit4.QuickPerfSpringRunner;
+import org.quickperf.spring.springboottest.FootballApplication;
+import org.quickperf.spring.springboottest.jpa.entity.Player;
+import org.quickperf.spring.springboottest.jpa.repository.PlayerRepository;
+import org.quickperf.sql.annotation.ExpectSelect;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.Ordered;
+
+import javax.sql.DataSource;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that QuickPerf proxies the DataSource even when another
+ * BeanPostProcessor directly depends on it.
+ */
+@RunWith(QuickPerfSpringRunner.class)
+@SpringBootTest(classes = {FootballApplication.class})
+@Import(BeanPostProcessorWithDataSourceDependency.Config.class)
+public class BeanPostProcessorWithDataSourceDependency {
+
+    @Autowired
+    private PlayerRepository playerRepository;
+
+    @ExpectSelect(2)
+    @Test
+    public void should_proxy_datasource_even_when_other_bean_post_processor_depends_on_datasource() {
+        List<Player> players = playerRepository.findAll();
+        assertThat(players).hasSize(2);
+    }
+
+    static class OrderedBeanPostProcessorWithDataSourceDependency implements BeanPostProcessor, Ordered {
+
+        // DataSource dependency forces early creation of the DataSource during BeanPostProcessor instantiation.
+        OrderedBeanPostProcessorWithDataSourceDependency(DataSource dataSource) {
+        }
+
+        @Override
+        public Object postProcessBeforeInitialization(Object bean, String beanName) {
+            return bean;
+        }
+
+        @Override
+        public Object postProcessAfterInitialization(Object bean, String beanName) {
+            return bean;
+        }
+
+        @Override
+        public int getOrder() {
+            return 0;
+        }
+    }
+
+    static class Config {
+
+        // Must be static so Spring detects this BeanPostProcessor during registerBeanPostProcessors()
+        @Bean
+        static OrderedBeanPostProcessorWithDataSourceDependency orderedBeanPostProcessorWithDataSourceDependency(DataSource dataSource) {
+            return new OrderedBeanPostProcessorWithDataSourceDependency(dataSource);
+        }
+    }
+}

--- a/spring/junit4-spring-boot-test/src/test/java/org/quickperf/spring/springboottest/SpringBoot2BeanPostProcessorWithDataSourceDependencyJunit4Test.java
+++ b/spring/junit4-spring-boot-test/src/test/java/org/quickperf/spring/springboottest/SpringBoot2BeanPostProcessorWithDataSourceDependencyJunit4Test.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2022 the original author or authors.
+ */
+package org.quickperf.spring.springboottest;
+
+import org.junit.Test;
+import org.junit.experimental.results.PrintableResult;
+import org.quickperf.spring.springboottest.beanPostProcessor.BeanPostProcessorWithDataSourceDependency;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SpringBoot2BeanPostProcessorWithDataSourceDependencyJunit4Test {
+
+    @Test
+    public void should_fail_if_select_number_is_different_from_expected_even_when_other_bean_post_processor_depends_on_datasource() {
+
+        // GIVEN
+        Class<?> testClass = BeanPostProcessorWithDataSourceDependency.class;
+
+        // WHEN
+        PrintableResult printableResult = PrintableResult.testResult(testClass);
+
+        // THEN
+        assertThat(printableResult.failureCount()).isOne();
+
+        String testReport = printableResult.toString();
+        assertThat(testReport)
+                      .contains("You may think that <2> select statements were sent to the database")
+                      .contains("But there is in fact <1>");
+
+    }
+
+}

--- a/spring/junit4-spring-boot-test/src/test/java/org/quickperf/spring/springboottest/beanPostProcessor/BeanPostProcessorWithDataSourceDependency.java
+++ b/spring/junit4-spring-boot-test/src/test/java/org/quickperf/spring/springboottest/beanPostProcessor/BeanPostProcessorWithDataSourceDependency.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2022 the original author or authors.
+ */
+package org.quickperf.spring.springboottest.beanPostProcessor;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.quickperf.spring.junit4.QuickPerfSpringRunner;
+import org.quickperf.spring.springboottest.FootballApplication;
+import org.quickperf.spring.springboottest.jpa.entity.Player;
+import org.quickperf.spring.springboottest.jpa.repository.PlayerRepository;
+import org.quickperf.sql.annotation.ExpectSelect;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.Ordered;
+
+import javax.sql.DataSource;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that QuickPerf proxies the DataSource even when another
+ * BeanPostProcessor directly depends on it.
+ */
+@RunWith(QuickPerfSpringRunner.class)
+@SpringBootTest(classes = {FootballApplication.class})
+@Import(BeanPostProcessorWithDataSourceDependency.Config.class)
+public class BeanPostProcessorWithDataSourceDependency {
+
+    @Autowired
+    private PlayerRepository playerRepository;
+
+    @ExpectSelect(2)
+    @Test
+    public void should_proxy_datasource_even_when_other_bean_post_processor_depends_on_datasource() {
+        List<Player> players = playerRepository.findAll();
+        assertThat(players).hasSize(2);
+    }
+
+    static class OrderedBeanPostProcessorWithDataSourceDependency implements BeanPostProcessor, Ordered {
+
+        // DataSource dependency forces early creation of the DataSource during BeanPostProcessor instantiation.
+        OrderedBeanPostProcessorWithDataSourceDependency(DataSource dataSource) {
+        }
+
+        @Override
+        public int getOrder() {
+            return 0;
+        }
+    }
+
+    static class Config {
+
+        // Must be static so Spring detects this BeanPostProcessor during registerBeanPostProcessors()
+        @Bean
+        static OrderedBeanPostProcessorWithDataSourceDependency orderedBeanPostProcessorWithDataSourceDependency(DataSource dataSource) {
+            return new OrderedBeanPostProcessorWithDataSourceDependency(dataSource);
+        }
+    }
+}

--- a/spring/junit5-spring-boot-3-test/src/test/java/org/quickperf/spring/springboottest/SpringBoot3BeanPostProcessorWithDataSourceDependencyJunit5Test.java
+++ b/spring/junit5-spring-boot-3-test/src/test/java/org/quickperf/spring/springboottest/SpringBoot3BeanPostProcessorWithDataSourceDependencyJunit5Test.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2022 the original author or authors.
+ */
+package org.quickperf.spring.springboottest;
+
+import org.junit.jupiter.api.Test;
+import org.quickperf.junit5.JUnit5Tests;
+import org.quickperf.junit5.JUnit5Tests.JUnit5TestsResult;
+import org.quickperf.spring.springboottest.beanPostProcessor.BeanPostProcessorWithDataSourceDependency;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SpringBoot3BeanPostProcessorWithDataSourceDependencyJunit5Test {
+
+    @Test
+    void should_fail_if_select_number_is_different_from_expected_even_when_other_bean_post_processor_depends_on_datasource() {
+
+        // GIVEN
+        Class<?> testClass = BeanPostProcessorWithDataSourceDependency.class;
+        JUnit5Tests jUnit5Tests = JUnit5Tests.createInstance(testClass);
+
+        // WHEN
+        JUnit5TestsResult jUnit5TestsResult = jUnit5Tests.run();
+
+        // THEN
+        assertThat(jUnit5TestsResult.getNumberOfFailures()).isOne();
+
+        String errorReport = jUnit5TestsResult.getErrorReport();
+        assertThat(errorReport)
+                      .contains("You may think that <2> select statements were sent to the database")
+                      .contains("But there is in fact <1>");
+
+    }
+
+}

--- a/spring/junit5-spring-boot-3-test/src/test/java/org/quickperf/spring/springboottest/beanPostProcessor/BeanPostProcessorWithDataSourceDependency.java
+++ b/spring/junit5-spring-boot-3-test/src/test/java/org/quickperf/spring/springboottest/beanPostProcessor/BeanPostProcessorWithDataSourceDependency.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2019-2022 the original author or authors.
+ */
+package org.quickperf.spring.springboottest.beanPostProcessor;
+
+import org.junit.jupiter.api.Test;
+import org.quickperf.junit5.QuickPerfTest;
+import org.quickperf.spring.springboottest.FootballApplication;
+import org.quickperf.spring.springboottest.jpa.entity.Player;
+import org.quickperf.spring.springboottest.jpa.repository.PlayerRepository;
+import org.quickperf.sql.annotation.ExpectSelect;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.Ordered;
+
+import javax.sql.DataSource;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that QuickPerf proxies the DataSource even when another
+ * BeanPostProcessor directly depends on it.
+ */
+@QuickPerfTest
+@SpringBootTest(classes = {FootballApplication.class})
+@Import(BeanPostProcessorWithDataSourceDependency.Config.class)
+public class BeanPostProcessorWithDataSourceDependency {
+
+    @Autowired
+    private PlayerRepository playerRepository;
+
+    @ExpectSelect(2)
+    @Test
+    void should_proxy_datasource_even_when_other_bean_post_processor_depends_on_datasource() {
+        List<Player> players = playerRepository.findAll();
+        assertThat(players).hasSize(2);
+    }
+
+    static class OrderedBeanPostProcessorWithDataSourceDependency implements BeanPostProcessor, Ordered {
+
+        // DataSource dependency forces early creation of the DataSource during BeanPostProcessor instantiation.
+        OrderedBeanPostProcessorWithDataSourceDependency(DataSource dataSource) {
+        }
+
+        @Override
+        public int getOrder() {
+            return 0;
+        }
+    }
+
+    static class Config {
+
+        // Must be static so Spring detects this BeanPostProcessor during registerBeanPostProcessors()
+        @Bean
+        static OrderedBeanPostProcessorWithDataSourceDependency orderedBeanPostProcessorWithDataSourceDependency(DataSource dataSource) {
+            return new OrderedBeanPostProcessorWithDataSourceDependency(dataSource);
+        }
+    }
+}

--- a/spring/sql-spring4/src/main/java/org/quickperf/spring/sql/QuickPerfProxyBeanPostProcessor.java
+++ b/spring/sql-spring4/src/main/java/org/quickperf/spring/sql/QuickPerfProxyBeanPostProcessor.java
@@ -18,17 +18,20 @@ import org.quickperf.sql.config.QuickPerfSqlDataSourceBuilder;
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.aop.scope.ScopedProxyUtils;
 import org.springframework.beans.factory.config.BeanPostProcessor;
-import org.springframework.core.Ordered;
+import org.springframework.core.PriorityOrdered;
 import org.springframework.util.ReflectionUtils;
 
 import javax.sql.DataSource;
 import java.lang.reflect.Method;
 
-/*
-Inspiration from https://blog.arnoldgalovics.com/configuring-a-datasource-proxy-in-spring-boot/
-and https://github.com/gavlyukovskiy/spring-boot-data-source-decorator
-*/
-public class QuickPerfProxyBeanPostProcessor implements BeanPostProcessor, Ordered {
+
+// Inspiration from https://blog.arnoldgalovics.com/configuring-a-datasource-proxy-in-spring-boot/
+// and https://github.com/gavlyukovskiy/spring-boot-data-source-decorator
+
+// Implements PriorityOrdered (not Ordered) so this BeanPostProcessor is registered before any
+// Ordered BeanPostProcessor that depends on the DataSource. Spring instantiates PriorityOrdered
+// bean post-processors first.
+public class QuickPerfProxyBeanPostProcessor implements BeanPostProcessor, PriorityOrdered {
 
     @Override
     public Object postProcessBeforeInitialization(Object bean, String beanName) {
@@ -48,7 +51,7 @@ public class QuickPerfProxyBeanPostProcessor implements BeanPostProcessor, Order
 
     @Override
     public int getOrder() {
-        return Ordered.LOWEST_PRECEDENCE - 1;
+        return PriorityOrdered.LOWEST_PRECEDENCE - 1;
     }
 
     private static class ProxyDataSourceInterceptor implements MethodInterceptor {

--- a/spring/sql-spring5/src/main/java/org/quickperf/spring/sql/QuickPerfProxyBeanPostProcessor.java
+++ b/spring/sql-spring5/src/main/java/org/quickperf/spring/sql/QuickPerfProxyBeanPostProcessor.java
@@ -18,17 +18,19 @@ import org.quickperf.sql.config.QuickPerfSqlDataSourceBuilder;
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.aop.scope.ScopedProxyUtils;
 import org.springframework.beans.factory.config.BeanPostProcessor;
-import org.springframework.core.Ordered;
+import org.springframework.core.PriorityOrdered;
 import org.springframework.util.ReflectionUtils;
 
 import javax.sql.DataSource;
 import java.lang.reflect.Method;
 
-/*
-Inspiration from https://blog.arnoldgalovics.com/configuring-a-datasource-proxy-in-spring-boot/
-and https://github.com/gavlyukovskiy/spring-boot-data-source-decorator
-*/
-public class QuickPerfProxyBeanPostProcessor implements BeanPostProcessor, Ordered {
+// Inspiration from https://blog.arnoldgalovics.com/configuring-a-datasource-proxy-in-spring-boot/
+// and https://github.com/gavlyukovskiy/spring-boot-data-source-decorator
+
+// Implements PriorityOrdered (not Ordered) so this BeanPostProcessor is registered before any
+// Ordered BeanPostProcessor that depends on the DataSource. Spring instantiates PriorityOrdered
+// bean post-processors first.
+public class QuickPerfProxyBeanPostProcessor implements BeanPostProcessor, PriorityOrdered {
 
     @Override
     public Object postProcessBeforeInitialization(Object bean, String beanName) {
@@ -48,7 +50,7 @@ public class QuickPerfProxyBeanPostProcessor implements BeanPostProcessor, Order
 
     @Override
     public int getOrder() {
-        return Ordered.LOWEST_PRECEDENCE - 1;
+        return PriorityOrdered.LOWEST_PRECEDENCE - 1;
     }
 
     private static class ProxyDataSourceInterceptor implements MethodInterceptor {


### PR DESCRIPTION
Fix an issue where QuickPerf's Spring `QuickPerfProxyBeanPostProcessor` could fail to proxy the DataSource when another Spring `BeanPostProcessor` implementing `Ordered` directly depends on it.